### PR TITLE
Mark users premium on subscription checkout sessions

### DIFF
--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -67,6 +67,14 @@ export default async function handler(req, res) {
             .update(update)
             .eq("id", user_id);
           if (error) throw error;
+
+          if (subscriptionId) {
+            const { error: premiumError } = await supabaseAdmin
+              .from("users")
+              .update({ is_premium: true })
+              .eq("id", user_id);
+            if (premiumError) throw premiumError;
+          }
         }
         break;
       }


### PR DESCRIPTION
## Summary
- ensure checkout session completion sets the user's Stripe subscription id
- mark users as premium when checkout sessions include a subscription

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c87f7ea698832bac7107a80d9c70d9