### PR TITLE
Refresh app interface layout and usability

### DIFF
--- a/app.html
+++ b/app.html
@@ -7,53 +7,388 @@
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <style>
   :root{
-    --bg:#0b1522; --panel:#111b2a; --muted:#1a2740; --text:#e7eefc;
-    --sub:#b7c6e9; --accent:#6ee7bf; --accent-2:#4ade80; --danger:#ef4444;
-    --btn:#1f2a44; --btn-h:#273354; --tab:#1b2743; --tab-a:#243355;
+    --bg:#050b17;
+    --panel:rgba(12,22,39,0.92);
+    --panel-strong:rgba(17,31,52,0.95);
+    --muted:rgba(22,34,54,0.8);
+    --text:#f1f5ff;
+    --sub:#8ca3cc;
+    --accent:#60a5fa;
+    --accent-2:#4ade80;
+    --danger:#ef4444;
+    --btn:rgba(42,60,100,0.9);
+    --btn-h:rgba(58,82,134,0.95);
+    --tab:rgba(20,33,54,0.6);
+    --tab-a:rgba(47,85,151,0.82);
+    --shadow:0 28px 65px -35px rgba(7,11,24,0.9);
+    --radius:18px;
   }
-  *{box-sizing:border-box} body{margin:0;background:linear-gradient(180deg,#0a1420,#0c1726);
-    color:var(--text);font:16px/1.45 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial}
-  .container{max-width:1100px;margin:20px auto;padding:0 16px}
-  header{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}
-  .brand{font-weight:800;font-size:22px}
-  .right-actions{display:flex;gap:10px;align-items:center}
-  button, .btn{background:var(--btn);border:1px solid #2a3a63;color:var(--text);border-radius:10px;
-    padding:10px 14px;cursor:pointer;transition:.15s;font-weight:600}
-  button:hover,.btn:hover{background:var(--btn-h)}
-  .btn-green{background:linear-gradient(180deg,#22c55e,#16a34a);border:none}
-  .btn-green:hover{filter:brightness(1.05)}
-  .btn-red{background:linear-gradient(180deg,#ef4444,#dc2626);border:none}
-  .panel{background:var(--panel);border:1px solid #22325a;border-radius:14px;padding:14px}
-  .controls{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-bottom:12px}
-  select,input,textarea{background:#0e1a2a;border:1px solid #22325a;color:var(--text);
-    padding:10px;border-radius:10px;outline:none}
-  input[type="date"]{padding:8px 10px}
-  textarea{resize:vertical}
-  .tabs{display:flex;gap:8px;margin:10px 0}
-  .tab{background:var(--tab);border:1px solid #26365e;border-radius:10px;padding:10px 14px;cursor:pointer}
-  .tab.active{background:var(--tab-a)}
-  .grid{display:grid;grid-template-columns:repeat(12,1fr);gap:10px}
-  .col-2{grid-column:span 2} .col-3{grid-column:span 3} .col-4{grid-column:span 4} .col-6{grid-column:span 6} .col-12{grid-column:span 12}
-  .hint{color:var(--sub);font-size:14px}
-  .banner{background:#3f1d1d;border:1px solid #6b1d1d;color:#ffd9d9;border-radius:12px;padding:12px 14px;margin:12px 0}
-  .badge{display:inline-block;padding:4px 8px;border-radius:999px;background:#12213a;border:1px solid #27406e;color:#9fb7e6;font-size:12px}
-  .row{display:grid;grid-template-columns:110px 1fr 1fr 90px 70px 120px 1fr 140px;gap:10px;align-items:center}
-  .row > div{padding:6px 0}
-  .actions{display:flex;gap:6px;flex-wrap:wrap}
-  .pill{padding:6px 10px;border-radius:8px;background:#0e1d32;border:1px solid #2a416e;font-size:13px;cursor:pointer}
-  .pill.win{background:#11341f;border-color:#2f6c48} .pill.loss{background:#341313;border-color:#6c2f2f}
-  .pill.pending{background:#1f2a44;border-color:#3b4d7c} .pill.void{background:#303030;border-color:#595959}
-  details.month{border:1px solid #22325a;background:#0d1828;border-radius:12px;padding:10px;margin-bottom:10px}
-  details.month summary{cursor:pointer;font-weight:700}
-  .stat{display:grid;grid-template-columns:1fr 1fr 1fr 1fr;gap:8px}
-  .stat .panel{padding:10px}
-  .hide{display:none}
+  *{box-sizing:border-box}
+  body{
+    margin:0;
+    min-height:100vh;
+    background:linear-gradient(180deg,#040914,#0d1729);
+    color:var(--text);
+    font:16px/1.5 "Inter","Segoe UI",-apple-system,BlinkMacSystemFont,"Helvetica Neue",Arial,sans-serif;
+    position:relative;
+  }
+  body::before{
+    content:"";
+    position:fixed;
+    inset:0;
+    background:radial-gradient(50% 60% at 18% 14%,rgba(96,165,250,0.22) 0%,rgba(5,11,23,0) 100%),
+      radial-gradient(55% 65% at 80% 12%,rgba(99,102,241,0.18) 0%,rgba(5,11,23,0) 100%);
+    pointer-events:none;
+    z-index:-1;
+  }
+  .container{
+    width:100%;
+    max-width:1220px;
+    margin:0 auto;
+    padding:36px 22px 64px;
+  }
+  header.top-bar{
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:24px;
+    margin-bottom:24px;
+    padding:22px 26px;
+    border-radius:var(--radius);
+    background:var(--panel-strong);
+    border:1px solid rgba(74,96,138,0.38);
+    box-shadow:var(--shadow);
+    backdrop-filter:blur(12px);
+  }
+  .brand-block{display:flex;flex-direction:column;gap:6px}
+  .brand{
+    font-weight:800;
+    font-size:28px;
+    letter-spacing:.02em;
+    background:linear-gradient(135deg,#a855f7,#38bdf8);
+    -webkit-background-clip:text;
+    color:transparent;
+  }
+  .tagline{margin:0;font-size:14px;color:var(--sub)}
+  .right-actions{display:flex;gap:12px;align-items:center;flex-wrap:wrap;justify-content:flex-end}
+  button,.btn{
+    background:var(--btn);
+    border:1px solid rgba(96,119,173,0.45);
+    color:var(--text);
+    border-radius:12px;
+    padding:10px 16px;
+    cursor:pointer;
+    transition:background .2s ease,transform .2s ease,border-color .2s ease;
+    font-weight:600;
+    letter-spacing:.01em;
+  }
+  button:hover,.btn:hover{background:var(--btn-h);transform:translateY(-1px);}
+  button:focus-visible,.btn:focus-visible{outline:2px solid var(--accent);outline-offset:3px;}
+  .btn-green{background:linear-gradient(135deg,#34d399,#10b981);border:none;box-shadow:0 12px 32px -20px rgba(16,185,129,0.7);}
+  .btn-green:hover{filter:brightness(1.05);}
+  .btn-red{background:linear-gradient(135deg,#f87171,#ef4444);border:none;box-shadow:0 12px 32px -20px rgba(239,68,68,0.65);}
+  .btn-red:hover{filter:brightness(1.05);}
+  .badge{
+    display:inline-flex;
+    align-items:center;
+    justify-content:center;
+    padding:6px 14px;
+    border-radius:999px;
+    background:rgba(59,130,246,0.12);
+    border:1px solid rgba(96,165,250,0.35);
+    color:var(--accent);
+    font-weight:600;
+    font-size:14px;
+  }
+  .banner{
+    display:flex;
+    align-items:flex-start;
+    justify-content:space-between;
+    gap:18px;
+    padding:18px 22px;
+    margin-bottom:24px;
+    border-radius:var(--radius);
+    background:linear-gradient(135deg,rgba(248,113,113,0.2),rgba(248,113,113,0.08));
+    border:1px solid rgba(248,113,113,0.45);
+    color:#ffe1e1;
+    box-shadow:0 18px 45px -30px rgba(248,113,113,0.45);
+  }
+  .banner h2{margin:0 0 4px;font-size:18px;color:#ffe1e1;}
+  .banner p{margin:0;font-size:15px;color:#ffd9d9;line-height:1.45;}
+  .workspace{
+    display:grid;
+    grid-template-columns:minmax(0,1fr) 320px;
+    gap:24px;
+    align-items:flex-start;
+  }
+  .primary,.secondary{display:flex;flex-direction:column;gap:24px;}
+  .panel{
+    background:var(--panel);
+    border:1px solid rgba(74,96,138,0.38);
+    border-radius:var(--radius);
+    padding:24px;
+    box-shadow:var(--shadow);
+    backdrop-filter:blur(12px);
+  }
+  .panel h2{margin:0;font-size:20px;font-weight:700;letter-spacing:.01em;}
+  .hint{color:var(--sub);font-size:14px;}
+  .subtle{color:var(--sub);font-size:13px;}
+  .section-header{
+    display:flex;
+    align-items:flex-start;
+    justify-content:space-between;
+    gap:20px;
+    margin-bottom:20px;
+  }
+  .section-header .project-meta{display:flex;align-items:center;gap:8px;color:var(--sub);font-size:13px;}
+  .section-header .project-meta strong{color:var(--text);font-size:16px;}
+  .project-controls{display:flex;flex-direction:column;gap:16px;}
+  .project-controls label{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--sub);}
+  .control-row{display:flex;flex-wrap:wrap;gap:12px;align-items:center;}
+  .control-row select{flex:1;min-width:220px;}
+  .button-cluster{display:flex;flex-wrap:wrap;gap:10px;}
+  select,input,textarea{
+    background:rgba(10,20,35,0.85);
+    border:1px solid rgba(78,106,150,0.4);
+    color:var(--text);
+    padding:12px 14px;
+    border-radius:12px;
+    font-size:15px;
+    transition:border .2s ease,box-shadow .2s ease,background .2s ease;
+  }
+  select:focus-visible,input:focus-visible,textarea:focus-visible{
+    border-color:rgba(96,165,250,0.8);
+    box-shadow:0 0 0 3px rgba(96,165,250,0.2);
+    outline:none;
+  }
+  textarea{resize:vertical;min-height:96px;}
+  .tabs{
+    display:flex;
+    gap:12px;
+    padding:6px;
+    background:rgba(15,26,44,0.7);
+    border:1px solid rgba(72,95,142,0.35);
+    border-radius:var(--radius);
+    box-shadow:var(--shadow);
+  }
+  .tab{
+    flex:1;
+    padding:12px 16px;
+    border-radius:12px;
+    border:1px solid transparent;
+    background:transparent;
+    color:var(--sub);
+    font-weight:600;
+    letter-spacing:.02em;
+    cursor:pointer;
+    transition:background .2s ease,color .2s ease,border .2s ease,transform .2s ease;
+  }
+  .tab:hover{color:var(--text);transform:translateY(-1px);}
+  .tab.active{
+    background:linear-gradient(135deg,rgba(96,165,250,0.28),rgba(56,189,248,0.16));
+    border-color:rgba(96,165,250,0.5);
+    color:var(--text);
+    box-shadow:0 12px 28px -20px rgba(96,165,250,0.7);
+  }
+  .grid{
+    display:grid;
+    grid-template-columns:repeat(12,minmax(0,1fr));
+    gap:16px;
+  }
+  .grid .field{display:flex;flex-direction:column;gap:6px;}
+  .grid label{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--sub);}
+  .col-1{grid-column:span 1;}
+  .col-2{grid-column:span 2;}
+  .col-3{grid-column:span 3;}
+  .col-4{grid-column:span 4;}
+  .col-5{grid-column:span 5;}
+  .col-6{grid-column:span 6;}
+  .col-12{grid-column:span 12;}
+  .actions{display:flex;flex-wrap:wrap;gap:12px;align-items:center;}
+  .action-field{align-self:end;}
+  .sr-only{
+    position:absolute;
+    width:1px;
+    height:1px;
+    padding:0;
+    margin:-1px;
+    overflow:hidden;
+    clip:rect(0,0,0,0);
+    white-space:nowrap;
+    border:0;
+  }
+  .summary-panel .filter{display:flex;flex-direction:column;gap:8px;min-width:190px;}
+  .summary-panel select{min-width:190px;}
+  .stat-grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(160px,1fr));
+    gap:16px;
+  }
+  .stat-card{
+    padding:18px;
+    border-radius:14px;
+    background:rgba(18,32,54,0.8);
+    border:1px solid rgba(73,103,152,0.4);
+    display:flex;
+    flex-direction:column;
+    gap:6px;
+  }
+  .stat-card .label{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--sub);}
+  .stat-card .value{font-size:26px;font-weight:700;}
+  .trend-card{
+    margin-top:20px;
+    padding:18px;
+    border-radius:14px;
+    background:rgba(22,36,58,0.8);
+    border:1px solid rgba(72,103,152,0.35);
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+    gap:12px;
+  }
+  .trend-card .label{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--sub);}
+  .trend-card .value{font-size:18px;font-weight:600;}
+  #playsContainer{display:flex;flex-direction:column;gap:16px;}
+  details.month{
+    border-radius:var(--radius);
+    border:1px solid rgba(72,103,152,0.35);
+    background:rgba(17,29,49,0.75);
+    overflow:hidden;
+    box-shadow:var(--shadow);
+  }
+  details.month summary{
+    list-style:none;
+    padding:18px 22px;
+    font-weight:700;
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:12px;
+    cursor:pointer;
+    background:linear-gradient(135deg,rgba(96,165,250,0.2),rgba(56,189,248,0.08));
+  }
+  details.month summary::-webkit-details-marker{display:none;}
+  details.month[open] summary{border-bottom:1px solid rgba(72,103,152,0.35);background:linear-gradient(135deg,rgba(96,165,250,0.08),rgba(56,189,248,0.05));}
+  .month-count{font-size:14px;color:var(--sub);}
+  .row{
+    display:grid;
+    grid-template-columns:120px 1.8fr 90px 90px 150px 1.4fr 220px;
+    gap:16px;
+    padding:16px 22px;
+    align-items:flex-start;
+  }
+  .row-head{
+    background:rgba(255,255,255,0.02);
+    font-size:12px;
+    letter-spacing:.08em;
+    text-transform:uppercase;
+    color:var(--sub);
+    font-weight:600;
+    padding-top:14px;
+    padding-bottom:14px;
+  }
+  .row:not(.row-head):nth-child(odd){background:rgba(10,18,32,0.3);}
+  .row > div{min-width:0;}
+  .cell-match .match{font-weight:600;display:block;}
+  .cell-match .market{display:block;font-size:13px;color:var(--sub);margin-top:2px;}
+  .note-cell{font-size:14px;line-height:1.4;opacity:.92;}
+  .actions{justify-content:flex-start;}
+  .pill{
+    padding:6px 12px;
+    border-radius:999px;
+    background:rgba(27,43,73,0.9);
+    border:1px solid rgba(71,103,152,0.4);
+    font-size:13px;
+    font-weight:600;
+    color:var(--text);
+    transition:transform .15s ease,background .2s ease,border .2s ease;
+    cursor:pointer;
+  }
+  .pill:hover{transform:translateY(-1px);background:rgba(46,69,104,0.95);}
+  .pill.win{background:rgba(22,101,52,0.28);border-color:rgba(134,239,172,0.45);color:#86efac;}
+  .pill.loss{background:rgba(153,27,27,0.28);border-color:rgba(248,113,113,0.5);color:#fca5a5;}
+  .pill.pending{background:rgba(30,64,175,0.25);border-color:rgba(129,140,248,0.45);color:#c7d2fe;}
+  .pill.void{background:rgba(107,114,128,0.25);border-color:rgba(156,163,175,0.45);color:#e5e7eb;}
+  .pill[data-del]{background:rgba(120,31,46,0.25);border-color:rgba(239,68,68,0.45);color:#fca5a5;}
+  .empty-state{
+    padding:32px 24px;
+    text-align:center;
+    background:rgba(17,31,52,0.75);
+    border:1px dashed rgba(99,102,241,0.35);
+    border-radius:var(--radius);
+    color:var(--sub);
+    font-size:15px;
+    line-height:1.6;
+  }
+  .highlight-panel{position:sticky;top:24px;}
+  .overview-grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
+    gap:16px;
+    margin-top:18px;
+  }
+  .overview-card{
+    padding:16px;
+    border-radius:14px;
+    background:rgba(18,32,54,0.72);
+    border:1px solid rgba(72,103,152,0.35);
+    display:flex;
+    flex-direction:column;
+    gap:6px;
+    transition:transform .2s ease,border .2s ease,background .2s ease;
+  }
+  .overview-card:hover{transform:translateY(-2px);border-color:rgba(96,165,250,0.5);background:rgba(21,38,62,0.8);}
+  .overview-card .label{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--sub);}
+  .overview-card .value{font-size:24px;font-weight:700;}
+  .tip-panel ul{margin:12px 0 0;padding-left:20px;color:var(--sub);line-height:1.6;}
+  .tip-panel li strong{color:var(--text);}
+  .hide{display:none!important;}
+  @media (max-width:1100px){
+    .workspace{grid-template-columns:1fr;}
+    .secondary{flex-direction:row;flex-wrap:wrap;}
+    .highlight-panel{position:static;}
+    .row{grid-template-columns:110px 1.6fr 80px 80px 140px 1.2fr 200px;}
+    .grid{grid-template-columns:repeat(6,minmax(0,1fr));}
+    .col-1,.col-2{grid-column:span 3;}
+    .col-3{grid-column:span 3;}
+    .col-4,.col-6{grid-column:span 6;}
+  }
+  @media (max-width:900px){
+    .row-head{display:none;}
+    .row{grid-template-columns:repeat(2,minmax(0,1fr));padding:14px 18px;border-bottom:1px solid rgba(72,103,152,0.25);}
+    .row:not(.row-head) > div{display:flex;flex-direction:column;gap:4px;}
+    .row:not(.row-head) > div::before{content:attr(data-label);font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--sub);font-weight:600;}
+    .actions{justify-content:flex-start;}
+  }
+  @media (max-width:760px){
+    .secondary{flex-direction:column;}
+  }
+  @media (max-width:720px){
+    .grid{grid-template-columns:repeat(1,minmax(0,1fr));}
+    .col-1,.col-2,.col-3,.col-4,.col-6,.col-12{grid-column:span 1;}
+    .action-field{align-self:auto;}
+    .actions{flex-direction:column;align-items:stretch;}
+    .tabs{flex-direction:column;}
+  }
+  @media (max-width:640px){
+    header.top-bar{flex-direction:column;align-items:flex-start;}
+    .right-actions{justify-content:flex-start;width:100%;}
+  }
+  @media (max-width:480px){
+    .right-actions{gap:10px;}
+    .right-actions button{width:100%;}
+    .badge{width:100%;justify-content:center;}
+    .banner{flex-direction:column;align-items:flex-start;}
+  }
 </style>
 </head>
 <body>
   <div class="container">
-    <header>
-      <div class="brand">BetSpread</div>
+    <header class="top-bar">
+      <div class="brand-block">
+        <div class="brand">BetSpread</div>
+        <p class="tagline">Planera, följ upp och förbättra dina spel.</p>
+      </div>
       <div class="right-actions">
         <span id="userEmail" class="badge">…</span>
         <button id="manageBillingBtn" title="Hantera abonnemang" class="hide">Hantera</button>
@@ -62,97 +397,154 @@
       </div>
     </header>
 
-    <div id="freeBanner" class="banner hide">Gratisläge: <span id="usedCount">0</span>/20 spel använda. Du har <span id="leftCount">20</span> kvar.</div>
-
-    <!-- Projektpanel -->
-    <div class="panel">
-      <div class="controls">
-        <label>Projekt</label>
-        <select id="projectSelect" style="min-width:260px"></select>
-        <button id="newProjectBtn">Nytt projekt</button>
-        <button id="renameProjectBtn">Byt namn</button>
-        <button id="deleteProjectBtn" class="btn-red">Radera</button>
+    <div id="freeBanner" class="banner hide">
+      <div>
+        <h2>Gratisläge</h2>
+        <p>Du har använt <strong id="usedCount">0</strong> av 20 spel. <br>Återstår: <strong id="leftCount">20</strong> spel.</p>
       </div>
+      <span class="hint">Uppgradera för obegränsade registreringar.</span>
     </div>
 
-    <!-- Flikar -->
-    <div class="tabs">
-      <div class="tab active" data-tab="reg">Registrera spel</div>
-      <div class="tab" data-tab="summary">Månadssummering</div>
-      <div class="tab" data-tab="list">Spel</div>
-    </div>
-
-    <!-- Registrera -->
-    <section id="tab-reg" class="panel">
-      <div class="grid">
-        <div class="col-2">
-          <label>Matchdag</label>
-          <input id="iDate" type="date" />
-        </div>
-        <div class="col-3">
-          <label>Match</label>
-          <input id="iMatch" type="text" placeholder="Arsenal — Chelsea" />
-        </div>
-        <div class="col-3">
-          <label>Marknad</label>
-          <input id="iMarket" type="text" placeholder="Över 8.5 frisparkar" />
-        </div>
-        <div class="col-2">
-          <label>Oddset</label>
-          <input id="iOdds" type="number" step="0.01" min="1.01" placeholder="1.85" />
-        </div>
-        <div class="col-1">
-          <label>Insats</label>
-          <input id="iStake" type="number" step="1" min="1" value="1"/>
-        </div>
-        <div class="col-1">
-          <label>Spelbolag</label>
-          <input id="iBook" type="text" placeholder="Bet365" />
+    <main class="workspace">
+      <section class="primary">
+        <div class="panel project-panel">
+          <div class="section-header">
+            <div>
+              <h2>Projekt</h2>
+              <p class="hint" id="projectTitle">Inget projekt valt</p>
+            </div>
+            <div class="project-meta">Projekt totalt: <strong id="projectCount">0</strong></div>
+          </div>
+          <div class="project-controls">
+            <label for="projectSelect">Välj projekt</label>
+            <div class="control-row">
+              <select id="projectSelect"></select>
+              <div class="button-cluster">
+                <button id="newProjectBtn">Nytt projekt</button>
+                <button id="renameProjectBtn">Byt namn</button>
+                <button id="deleteProjectBtn" class="btn-red">Radera</button>
+              </div>
+            </div>
+          </div>
         </div>
 
-        <div class="col-2">
-          <label>Resultat</label>
-          <select id="iResult">
-            <option>Pending</option><option>Win</option><option>Loss</option><option>Void</option>
-          </select>
-        </div>
-        <div class="col-6">
-          <label>Notering</label>
-          <input id="iNote" type="text" placeholder="Ex. sent mål, cashout, etc." />
-        </div>
-        <div class="col-4 actions" style="align-self:end">
-          <button id="addBetBtn" class="btn-green">Lägg till spel</button>
-          <button id="resetProjectBtn" class="btn-red">Nollställ projekt</button>
-        </div>
-      </div>
-    </section>
+        <nav class="tabs" role="tablist">
+          <button type="button" id="tab-reg-btn" class="tab active" data-tab="reg" role="tab" aria-controls="tab-reg" aria-selected="true">Registrera spel</button>
+          <button type="button" id="tab-summary-btn" class="tab" data-tab="summary" role="tab" aria-controls="tab-summary" aria-selected="false">Månadssummering</button>
+          <button type="button" id="tab-list-btn" class="tab" data-tab="list" role="tab" aria-controls="tab-list" aria-selected="false">Spel</button>
+        </nav>
 
-    <!-- Månadssummering -->
-    <section id="tab-summary" class="panel hide">
-      <div class="controls">
-        <label>Månad (matchdag)</label>
-        <select id="monthFilter"></select>
-      </div>
+        <section id="tab-reg" class="panel form-panel" role="tabpanel" aria-labelledby="tab-reg-btn" aria-hidden="false">
+          <div class="section-header">
+            <div>
+              <h2>Registrera spel</h2>
+              <p class="hint">Fyll i matchinformationen och klicka på &quot;Lägg till spel&quot; för att spara.</p>
+            </div>
+            <span class="subtle">Alla fält är obligatoriska</span>
+          </div>
+          <div class="grid">
+            <div class="col-2 field">
+              <label for="iDate">Matchdag</label>
+              <input id="iDate" type="date" />
+            </div>
+            <div class="col-3 field">
+              <label for="iMatch">Match</label>
+              <input id="iMatch" type="text" placeholder="Arsenal — Chelsea" />
+            </div>
+            <div class="col-3 field">
+              <label for="iMarket">Marknad</label>
+              <input id="iMarket" type="text" placeholder="Över 8.5 frisparkar" />
+            </div>
+            <div class="col-2 field">
+              <label for="iOdds">Oddset</label>
+              <input id="iOdds" type="number" step="0.01" min="1.01" placeholder="1.85" />
+            </div>
+            <div class="col-1 field">
+              <label for="iStake">Insats</label>
+              <input id="iStake" type="number" step="1" min="1" value="1" />
+            </div>
+            <div class="col-1 field">
+              <label for="iBook">Spelbolag</label>
+              <input id="iBook" type="text" placeholder="Bet365" />
+            </div>
+            <div class="col-2 field">
+              <label for="iResult">Resultat</label>
+              <select id="iResult">
+                <option>Pending</option>
+                <option>Win</option>
+                <option>Loss</option>
+                <option>Void</option>
+              </select>
+            </div>
+            <div class="col-6 field">
+              <label for="iNote">Notering</label>
+              <input id="iNote" type="text" placeholder="Ex. sent mål, cashout, etc." />
+            </div>
+            <div class="col-4 field action-field">
+              <span class="sr-only">Åtgärder</span>
+              <div class="actions">
+                <button id="addBetBtn" class="btn-green">Lägg till spel</button>
+                <button id="resetProjectBtn" class="btn-red">Nollställ projekt</button>
+              </div>
+            </div>
+          </div>
+        </section>
 
-      <div class="stat">
-        <div class="panel"><div class="hint">Spel (avgjorda)</div><div id="sGames" style="font-size:22px;font-weight:800">0</div></div>
-        <div class="panel"><div class="hint">Win</div><div id="sWins" style="font-size:22px;font-weight:800">0</div></div>
-        <div class="panel"><div class="hint">Profit</div><div id="sProfit" style="font-size:22px;font-weight:800">0.00</div></div>
-        <div class="panel"><div class="hint">ROI</div><div id="sRoi" style="font-size:22px;font-weight:800">0.00%</div></div>
-      </div>
+        <section id="tab-summary" class="panel summary-panel hide" role="tabpanel" aria-labelledby="tab-summary-btn" aria-hidden="true">
+          <div class="section-header">
+            <div>
+              <h2>Månadssummering</h2>
+              <p class="hint">Analysera avgjorda spel och följ ROI per månad.</p>
+            </div>
+            <div class="filter">
+              <label for="monthFilter">Månad (matchdag)</label>
+              <select id="monthFilter"></select>
+            </div>
+          </div>
+          <div class="stat-grid">
+            <div class="stat-card"><span class="label">Spel (avgjorda)</span><span id="sGames" class="value">0</span></div>
+            <div class="stat-card"><span class="label">Vinster</span><span id="sWins" class="value">0</span></div>
+            <div class="stat-card"><span class="label">Profit</span><span id="sProfit" class="value">0.00</span></div>
+            <div class="stat-card"><span class="label">ROI</span><span id="sRoi" class="value">0.00%</span></div>
+          </div>
+          <div class="trend-card">
+            <span class="label">Visar</span>
+            <span id="sMonthName" class="value">-</span>
+          </div>
+        </section>
 
-      <div style="margin-top:10px">
-        <div class="panel">
-          <div class="hint">Månad</div>
-          <div id="sMonthName" style="font-weight:700">-</div>
-        </div>
-      </div>
-    </section>
+        <section id="tab-list" class="panel list-panel hide" role="tabpanel" aria-labelledby="tab-list-btn" aria-hidden="true">
+          <div class="section-header">
+            <div>
+              <h2>Spel</h2>
+              <p class="hint">Hantera registrerade spel och uppdatera resultaten.</p>
+            </div>
+          </div>
+          <div id="playsContainer"></div>
+        </section>
+      </section>
 
-    <!-- Spel -->
-    <section id="tab-list" class="panel hide">
-      <div id="playsContainer"></div>
-    </section>
+      <aside class="secondary">
+        <section class="panel highlight-panel">
+          <h2>Snabböversikt</h2>
+          <p class="hint">Få koll på projektets status utan att lämna formuläret.</p>
+          <div class="overview-grid">
+            <div class="overview-card"><span class="label">Spel totalt</span><span id="quickTotal" class="value">0</span></div>
+            <div class="overview-card"><span class="label">Pågående</span><span id="quickPending" class="value">0</span></div>
+            <div class="overview-card"><span class="label">Vinstrate</span><span id="quickWinRate" class="value">–</span></div>
+            <div class="overview-card"><span class="label">Profit</span><span id="quickProfit" class="value">0.00</span></div>
+          </div>
+        </section>
+        <section class="panel tip-panel">
+          <h2>Tips</h2>
+          <ul class="tips-list">
+            <li><strong>Byt projekt</strong> i listan för att se andra spel.</li>
+            <li><strong>Använd flikarna</strong> för att registrera spel eller analysera resultat.</li>
+            <li><strong>Uppdatera resultat</strong> i spel-listan så hålls statistiken aktuell.</li>
+          </ul>
+        </section>
+      </aside>
+    </main>
   </div>
 
 <script type="module">
@@ -177,10 +569,17 @@
   const svMonth = (y,m) => new Date(y, m-1, 1).toLocaleDateString("sv-SE",{month:"long",year:"numeric"});
 
   function setTab(name){
-    $$(".tab").forEach(t => t.classList.toggle("active", t.dataset.tab===name));
-    $("#tab-reg").classList.toggle("hide", name!=="reg");
-    $("#tab-summary").classList.toggle("hide", name!=="summary");
-    $("#tab-list").classList.toggle("hide", name!=="list");
+    $$(".tab").forEach(t => {
+      const active = t.dataset.tab === name;
+      t.classList.toggle("active", active);
+      t.setAttribute("aria-selected", active ? "true" : "false");
+    });
+    const reg = $("#tab-reg");
+    const summary = $("#tab-summary");
+    const list = $("#tab-list");
+    if(reg){ reg.classList.toggle("hide", name!=="reg"); reg.setAttribute("aria-hidden", name!=="reg"); }
+    if(summary){ summary.classList.toggle("hide", name!=="summary"); summary.setAttribute("aria-hidden", name!=="summary"); }
+    if(list){ list.classList.toggle("hide", name!=="list"); list.setAttribute("aria-hidden", name!=="list"); }
   }
 
   $$(".tab").forEach(t => t.addEventListener("click",()=>setTab(t.dataset.tab)));
@@ -266,6 +665,7 @@
 
   function renderProjectSelect(){
     const sel = $("#projectSelect");
+    if(!sel) return;
     sel.innerHTML = "";
     for(const p of projects){
       const opt = document.createElement("option");
@@ -279,6 +679,14 @@
     }else if(currentProject){
       sel.value = currentProject.id;
     }
+    updateProjectMeta();
+  }
+
+  function updateProjectMeta(){
+    const title = $("#projectTitle");
+    if(title) title.textContent = currentProject?.name || "Inget projekt valt";
+    const count = $("#projectCount");
+    if(count) count.textContent = projects.length.toString();
   }
 
   $("#projectSelect").onchange = ()=>{
@@ -340,8 +748,12 @@
   };
 
   async function loadBets(){
+    updateProjectMeta();
+    const cont = $("#playsContainer");
     if(!currentProject){
-      $("#playsContainer").innerHTML="";
+      bets = [];
+      if(cont) cont.innerHTML = '<div class="empty-state">Välj eller skapa ett projekt för att börja registrera spel.</div>';
+      renderSummary();
       await updateFreeBanner();
       return;
     }
@@ -445,30 +857,44 @@
       (byMonth[ym] ||= []).push(b);
     }
     const cont = $("#playsContainer");
+    if(!cont) return;
     cont.innerHTML = "";
 
-    if(bets.length === 0){
-      cont.innerHTML = '<p class="hint">Inga spel registrerade ännu. Lägg till ditt första spel ovan.</p>';
+    if(!bets.length){
+      cont.innerHTML = '<div class="empty-state">Inga spel registrerade ännu. Lägg till ditt första spel via formuläret till vänster.</div>';
       return;
     }
+
+    const formatNumber = (value, decimals = 2) => {
+      const num = Number(value);
+      return Number.isFinite(num) ? num.toFixed(decimals) : "–";
+    };
+    const formatStake = value => {
+      const num = Number(value);
+      if(!Number.isFinite(num)) return "–";
+      return Number.isInteger(num) ? num.toString() : num.toFixed(2);
+    };
 
     Object.keys(byMonth).sort().reverse().forEach(ym=>{
       const arr = byMonth[ym];
       const [y,m] = ym.split("-").map(Number);
       const el = document.createElement("details");
       el.className = "month"; el.open = false;
-      el.innerHTML = `<summary>${svMonth(y,m)} (${arr.length} spel)</summary>`;
+      el.innerHTML = `<summary>${svMonth(y,m)}<span class="month-count">${arr.length} spel</span></summary>`;
 
       const header = document.createElement("div");
-      header.className = "row hint";
+      header.className = "row row-head";
       header.innerHTML = `
-        <div>Datum</div><div>Match</div><div>Marknad</div>
-        <div>Odds</div><div>Insats</div><div>Spelbolag</div>
-        <div>Notering</div><div>Resultat</div>`;
+        <div>Datum</div><div>Match &amp; Marknad</div><div>Odds</div>
+        <div>Insats</div><div>Spelbolag</div><div>Notering</div><div>Resultat</div>`;
       el.appendChild(header);
 
       for(const b of arr){
         const row = document.createElement("div"); row.className="row";
+        const matchInfo = `${b.match || "–"}`;
+        const marketInfo = b.market ? `<span class="market">${b.market}</span>` : "";
+        const book = b.book ? b.book : "–";
+        const note = b.note ? b.note : "–";
         const resHtml = `
           <div class="actions">
             <span class="pill win" data-r="Win">Win</span>
@@ -478,16 +904,14 @@
             <span class="pill" data-del="1" style="margin-left:6px">Ta bort</span>
           </div>`;
         row.innerHTML = `
-          <div>${b.matchday}</div>
-          <div>${b.match}</div>
-          <div>${b.market}</div>
-          <div>${b.odds}</div>
-          <div>${b.stake}</div>
-          <div>${b.book||""}</div>
-          <div>${b.note||""}</div>
-          <div>${resHtml}</div>
+          <div data-label="Datum">${b.matchday || "–"}</div>
+          <div data-label="Match &amp; Marknad" class="cell-match"><span class="match">${matchInfo}</span>${marketInfo}</div>
+          <div data-label="Odds">${formatNumber(b.odds, 2)}</div>
+          <div data-label="Insats">${formatStake(b.stake)}</div>
+          <div data-label="Spelbolag">${book}</div>
+          <div data-label="Notering" class="note-cell">${note}</div>
+          <div data-label="Resultat">${resHtml}</div>
         `;
-        // klickar på snabbknappar
         row.querySelectorAll(".pill").forEach(p=>{
           p.onclick = async ()=>{
             if(p.dataset.del){
@@ -513,7 +937,42 @@
     });
   }
 
-  // ======= RENDER MÅNADSSUMMERING =======
+  function renderQuickStats(){
+    const totalEl = $("#quickTotal");
+    if(!totalEl) return;
+    const total = bets.length;
+    const pending = bets.filter(b => b.result === "Pending").length;
+    const decided = bets.filter(b => b.result !== "Pending" && b.result !== "Void");
+    const wins = decided.filter(b => b.result === "Win").length;
+    const profit = bets.reduce((sum, b) => {
+      const stakeNum = Number(b.stake);
+      if(!Number.isFinite(stakeNum)) return sum;
+      if(b.result === "Win"){
+        const oddsNum = Number(b.odds);
+        return Number.isFinite(oddsNum) ? sum + (oddsNum - 1) * stakeNum : sum;
+      }
+      if(b.result === "Loss"){
+        return sum - stakeNum;
+      }
+      return sum;
+    }, 0);
+
+    totalEl.textContent = total.toString();
+    const pendingEl = $("#quickPending");
+    if(pendingEl) pendingEl.textContent = pending.toString();
+    const winRateEl = $("#quickWinRate");
+    if(winRateEl){
+      if(decided.length){
+        const rate = Math.round((wins / decided.length) * 1000) / 10;
+        winRateEl.textContent = `${rate.toFixed(1)}%`;
+      }else{
+        winRateEl.textContent = "–";
+      }
+    }
+    const profitEl = $("#quickProfit");
+    if(profitEl) profitEl.textContent = fmtMoney(profit);
+  }
+
   function recompute(monthFilter="all"){
     let data = bets;
     if(monthFilter!=="all"){
@@ -521,8 +980,22 @@
     }
     const decided = data.filter(b => b.result!=="Pending" && b.result!=="Void");
     const wins = decided.filter(b => b.result==="Win").length;
-    const stakeSum = decided.reduce((s,b)=>s+b.stake,0);
-    const profit = decided.reduce((s,b)=> s + (b.result==="Win" ? (b.odds-1)*b.stake : -b.stake), 0);
+    const stakeSum = decided.reduce((s,b)=>{
+      const stakeNum = Number(b.stake);
+      return Number.isFinite(stakeNum) ? s + stakeNum : s;
+    },0);
+    const profit = decided.reduce((s,b)=>{
+      const stakeNum = Number(b.stake);
+      if(!Number.isFinite(stakeNum)) return s;
+      if(b.result==="Win"){
+        const oddsNum = Number(b.odds);
+        return Number.isFinite(oddsNum) ? s + (oddsNum-1)*stakeNum : s;
+      }
+      if(b.result==="Loss"){
+        return s - stakeNum;
+      }
+      return s;
+    }, 0);
     const roi = stakeSum>0 ? (profit/stakeSum)*100 : 0;
 
     $("#sGames").textContent = decided.length.toString();
@@ -538,12 +1011,13 @@
   }
 
   function renderSummary(){
-    // fyll månadsväljare
     const months = [...new Set(bets.filter(b=>b.matchday).map(b=>b.matchday.slice(0,7)))].sort().reverse();
     const sel = $("#monthFilter");
+    if(!sel) return;
     sel.innerHTML = `<option value="all">Alla månader</option>` + months.map(m=>`<option value="${m}">${m}</option>`).join("");
     sel.onchange = ()=>recompute(sel.value);
     recompute(sel.value||"all");
+    renderQuickStats();
   }
 
   // ======= INIT =======
@@ -555,7 +1029,6 @@
       return;
     }
 
-    // förifyll dagens datum
     $("#iDate").valueAsDate = new Date();
 
     await loadProjects();


### PR DESCRIPTION
## Summary
- redesign the app layout with updated styling, responsive panels, and an improved project toolbar
- add a quick stats sidebar with sticky positioning and richer tab panels for registration, summary, and bet management
- enhance bet list rendering, quick metrics, and ROI calculations to present data clearly and handle invalid numbers gracefully

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c88467640c832ba150a53580cec558