### PR TITLE
Rebalance dashboard layout in app

### DIFF
--- a/app.css
+++ b/app.css
@@ -1,0 +1,562 @@
+:root {
+  --bg: #050712;
+  --bg-alt: #090d1c;
+  --panel: rgba(13, 18, 37, 0.92);
+  --panel-strong: rgba(17, 25, 46, 0.96);
+  --border: rgba(82, 108, 173, 0.45);
+  --border-soft: rgba(82, 108, 173, 0.25);
+  --text: #f1f5ff;
+  --muted: #97a6cd;
+  --accent: #60a5fa;
+  --accent-2: #34d399;
+  --danger: #f87171;
+  --radius: 18px;
+  --shadow: 0 28px 68px -32px rgba(6, 9, 18, 0.9);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  color: var(--text);
+  background: radial-gradient(100% 100% at 10% 0%, rgba(96, 165, 250, 0.25), rgba(5, 7, 18, 0) 60%),
+    radial-gradient(80% 80% at 90% 10%, rgba(110, 231, 183, 0.18), rgba(5, 7, 18, 0) 70%),
+    linear-gradient(180deg, #04060f, #0d1529 60%, #070b14 100%);
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 26px min(4vw, 48px) 16px;
+}
+
+.brand {
+  font-size: clamp(1.6rem, 2.2vw, 2.4rem);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  background: linear-gradient(135deg, #38bdf8 0%, #a855f7 70%);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.header-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  font-size: 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  background: rgba(8, 20, 45, 0.7);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+button,
+.btn {
+  border: 1px solid var(--border);
+  background: rgba(20, 32, 58, 0.85);
+  color: var(--text);
+  border-radius: 12px;
+  padding: 10px 18px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+button:hover,
+.btn:hover {
+  transform: translateY(-1px);
+  background: rgba(35, 52, 83, 0.9);
+  border-color: rgba(110, 168, 255, 0.6);
+}
+
+button:focus-visible,
+.btn:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.8);
+  outline-offset: 3px;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  border-color: transparent;
+  box-shadow: 0 16px 32px -22px rgba(37, 99, 235, 0.7);
+}
+
+.btn.primary:hover { filter: brightness(1.05); }
+
+.btn.danger {
+  background: linear-gradient(135deg, #f87171, #ef4444);
+  border: none;
+  box-shadow: 0 16px 36px -24px rgba(239, 68, 68, 0.75);
+}
+
+.btn.ghost {
+  background: rgba(18, 28, 48, 0.6);
+  border: 1px solid rgba(102, 126, 173, 0.6);
+}
+
+.hide { display: none !important; }
+
+.notice {
+  margin: 0 auto;
+  width: min(1120px, 92%);
+  margin-bottom: 20px;
+  padding: 18px 24px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(248, 180, 180, 0.45);
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.18), rgba(248, 113, 113, 0.08));
+  color: #ffe4e4;
+  box-shadow: 0 22px 54px -34px rgba(248, 113, 113, 0.55);
+}
+
+.app-main {
+  width: min(1180px, 94%);
+  margin: 0 auto 64px;
+}
+
+.primary {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.panel {
+  position: relative;
+  border-radius: var(--radius);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  padding: 26px 24px;
+  backdrop-filter: blur(14px);
+}
+
+.panel h2 {
+  margin: 0 0 12px;
+  font-size: 1.2rem;
+  letter-spacing: 0.01em;
+}
+
+.panel .subtle {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.top-board {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(260px, 0.85fr);
+  gap: 24px;
+  align-items: stretch;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.project-card {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.project-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.project-name {
+  margin: 4px 0 0;
+  font-size: clamp(1.3rem, 2vw, 1.6rem);
+  font-weight: 700;
+}
+
+.count-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(96, 125, 180, 0.4);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.project-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+}
+
+.project-controls select {
+  min-width: 0;
+}
+
+.project-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+select,
+input,
+textarea {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--border-soft);
+  background: rgba(10, 17, 32, 0.9);
+  color: var(--text);
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+select:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  border-color: rgba(110, 168, 255, 0.7);
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.18);
+  outline: none;
+}
+
+.tabs {
+  display: flex;
+  gap: 12px;
+  padding: 8px;
+  border-radius: var(--radius);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(82, 108, 173, 0.35);
+}
+
+.tab {
+  flex: 1;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  padding: 12px 16px;
+  font-weight: 600;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.tab:hover { color: var(--text); transform: translateY(-1px); }
+
+.tab.active {
+  color: var(--text);
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.3), rgba(59, 130, 246, 0.12));
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.tab-panel.hide { display: none; }
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.col-12 { grid-column: span 12; }
+.col-6 { grid-column: span 6; }
+.col-4 { grid-column: span 4; }
+.col-3 { grid-column: span 3; }
+.col-2 { grid-column: span 2; }
+.col-1 { grid-column: span 1; }
+
+label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--muted);
+}
+
+.form-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.summary-card {
+  padding: 18px;
+  border-radius: 14px;
+  background: rgba(16, 24, 46, 0.88);
+  border: 1px solid rgba(96, 125, 180, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.summary-card .label { color: var(--muted); font-size: 0.85rem; }
+.summary-card .value { font-size: 1.45rem; font-weight: 700; }
+
+.summary-meta {
+  margin-top: 20px;
+  padding: 18px;
+  border-radius: 14px;
+  background: rgba(11, 19, 36, 0.9);
+  border: 1px solid rgba(80, 114, 180, 0.35);
+}
+
+.summary-meta .label { color: var(--muted); font-size: 0.85rem; }
+.summary-meta .value { font-size: 1rem; font-weight: 600; }
+
+.empty-state {
+  padding: 32px;
+  text-align: center;
+  border-radius: 16px;
+  background: rgba(13, 23, 45, 0.7);
+  border: 1px dashed rgba(96, 125, 180, 0.4);
+  color: var(--muted);
+}
+
+details.month {
+  border-radius: 16px;
+  border: 1px solid rgba(80, 114, 180, 0.3);
+  background: rgba(9, 16, 32, 0.78);
+  margin-bottom: 16px;
+  padding: 10px 14px;
+}
+
+details.month[open] { background: rgba(12, 24, 46, 0.82); }
+
+details.month summary {
+  list-style: none;
+  cursor: pointer;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 2px;
+  color: var(--text);
+}
+
+details.month summary::-webkit-details-marker { display: none; }
+
+.month-count {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1.2fr) 80px 80px 120px 1fr;
+  gap: 12px;
+  align-items: start;
+  padding: 10px 6px;
+}
+
+.row-head {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+}
+
+.market {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  border: 1px solid transparent;
+}
+
+.status-badge.win { background: rgba(16, 185, 129, 0.18); border-color: rgba(16, 185, 129, 0.35); color: #6ee7bf; }
+.status-badge.loss { background: rgba(239, 68, 68, 0.18); border-color: rgba(239, 68, 68, 0.35); color: #fca5a5; }
+.status-badge.pending { background: rgba(96, 165, 250, 0.18); border-color: rgba(96, 165, 250, 0.32); color: #bfdbfe; }
+.status-badge.void { background: rgba(148, 163, 184, 0.18); border-color: rgba(148, 163, 184, 0.3); color: #e2e8f0; }
+
+.result-cell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.action-dropdown {
+  position: relative;
+}
+
+.dropdown-toggle {
+  border-radius: 10px;
+  padding: 8px 14px;
+  background: rgba(24, 34, 58, 0.85);
+  border: 1px solid rgba(96, 125, 180, 0.5);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.dropdown-toggle[aria-expanded="true"],
+.dropdown-toggle:hover {
+  background: rgba(42, 60, 100, 0.95);
+}
+
+.action-dropdown .action-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 210px;
+  background: rgba(10, 17, 35, 0.98);
+  border-radius: 12px;
+  border: 1px solid rgba(80, 114, 180, 0.35);
+  box-shadow: 0 18px 45px -28px rgba(8, 12, 24, 0.85);
+  padding: 8px;
+  display: none;
+  z-index: 20;
+}
+
+.action-dropdown.open .action-menu { display: flex; flex-direction: column; }
+
+.action-menu button {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  padding: 10px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+.action-menu button:hover,
+.action-menu button:focus-visible {
+  background: rgba(59, 130, 246, 0.18);
+  outline: none;
+}
+
+.stats-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.stats-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.stats-heading h2 {
+  margin: 0;
+}
+
+.stats-heading p {
+  margin: 0;
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.overview-card {
+  border-radius: 14px;
+  padding: 18px;
+  background: rgba(11, 20, 38, 0.85);
+  border: 1px solid rgba(96, 125, 180, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.overview-card .label { color: var(--muted); font-size: 0.85rem; }
+.overview-card .value { font-size: 1.5rem; font-weight: 700; }
+
+@media (max-width: 1080px) {
+  .top-board {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-grid { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+}
+
+@media (max-width: 720px) {
+  .app-header { flex-direction: column; align-items: flex-start; }
+  .header-meta { justify-content: flex-start; }
+  .project-header { flex-direction: column; align-items: flex-start; gap: 12px; }
+  .count-chip { align-self: flex-start; }
+  .project-controls { grid-template-columns: 1fr; }
+  .project-buttons { justify-content: flex-start; }
+  .form-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  .col-6 { grid-column: span 6; }
+  .col-4 { grid-column: span 6; }
+  .col-3 { grid-column: span 6; }
+  .col-2 { grid-column: span 3; }
+  .col-1 { grid-column: span 3; }
+  .row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .row > div:nth-child(3),
+  .row > div:nth-child(4),
+  .row > div:nth-child(5),
+  .row > div:nth-child(6) { margin-top: 6px; }
+  .result-cell { flex-direction: column; align-items: flex-start; }
+  .dropdown-toggle { width: 100%; }
+}

--- a/app.html
+++ b/app.html
@@ -5,562 +5,161 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>BetSpread – App</title>
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-<style>
-  :root{
-    --bg:#0b1522; --panel:#111b2a; --muted:#1a2740; --text:#e7eefc;
-    --sub:#b7c6e9; --accent:#6ee7bf; --accent-2:#4ade80; --danger:#ef4444;
-    --btn:#1f2a44; --btn-h:#273354; --tab:#1b2743; --tab-a:#243355;
-  }
-  *{box-sizing:border-box} body{margin:0;background:linear-gradient(180deg,#0a1420,#0c1726);
-    color:var(--text);font:16px/1.45 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial}
-  .container{max-width:1100px;margin:20px auto;padding:0 16px}
-  header{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}
-  .brand{font-weight:800;font-size:22px}
-  .right-actions{display:flex;gap:10px;align-items:center}
-  button, .btn{background:var(--btn);border:1px solid #2a3a63;color:var(--text);border-radius:10px;
-    padding:10px 14px;cursor:pointer;transition:.15s;font-weight:600}
-  button:hover,.btn:hover{background:var(--btn-h)}
-  .btn-green{background:linear-gradient(180deg,#22c55e,#16a34a);border:none}
-  .btn-green:hover{filter:brightness(1.05)}
-  .btn-red{background:linear-gradient(180deg,#ef4444,#dc2626);border:none}
-  .panel{background:var(--panel);border:1px solid #22325a;border-radius:14px;padding:14px}
-  .controls{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-bottom:12px}
-  select,input,textarea{background:#0e1a2a;border:1px solid #22325a;color:var(--text);
-    padding:10px;border-radius:10px;outline:none}
-  input[type="date"]{padding:8px 10px}
-  textarea{resize:vertical}
-  .tabs{display:flex;gap:8px;margin:10px 0}
-  .tab{background:var(--tab);border:1px solid #26365e;border-radius:10px;padding:10px 14px;cursor:pointer}
-  .tab.active{background:var(--tab-a)}
-  .grid{display:grid;grid-template-columns:repeat(12,1fr);gap:10px}
-  .col-2{grid-column:span 2} .col-3{grid-column:span 3} .col-4{grid-column:span 4} .col-6{grid-column:span 6} .col-12{grid-column:span 12}
-  .hint{color:var(--sub);font-size:14px}
-  .banner{background:#3f1d1d;border:1px solid #6b1d1d;color:#ffd9d9;border-radius:12px;padding:12px 14px;margin:12px 0}
-  .badge{display:inline-block;padding:4px 8px;border-radius:999px;background:#12213a;border:1px solid #27406e;color:#9fb7e6;font-size:12px}
-  .row{display:grid;grid-template-columns:110px 1fr 1fr 90px 70px 120px 1fr 140px;gap:10px;align-items:center}
-  .row > div{padding:6px 0}
-  .actions{display:flex;gap:6px;flex-wrap:wrap}
-  .pill{padding:6px 10px;border-radius:8px;background:#0e1d32;border:1px solid #2a416e;font-size:13px;cursor:pointer}
-  .pill.win{background:#11341f;border-color:#2f6c48} .pill.loss{background:#341313;border-color:#6c2f2f}
-  .pill.pending{background:#1f2a44;border-color:#3b4d7c} .pill.void{background:#303030;border-color:#595959}
-  details.month{border:1px solid #22325a;background:#0d1828;border-radius:12px;padding:10px;margin-bottom:10px}
-  details.month summary{cursor:pointer;font-weight:700}
-  .stat{display:grid;grid-template-columns:1fr 1fr 1fr 1fr;gap:8px}
-  .stat .panel{padding:10px}
-  .hide{display:none}
-</style>
+<link rel="stylesheet" href="./app.css">
+
 </head>
 <body>
-  <div class="container">
-    <header>
+  <div class="app-shell">
+    <header class="app-header">
       <div class="brand">BetSpread</div>
-      <div class="right-actions">
-        <span id="userEmail" class="badge">…</span>
-        <button id="manageBillingBtn" title="Hantera abonnemang" class="hide">Hantera</button>
-        <button id="upgradeBtn" class="btn-green">Uppgradera</button>
-        <button id="logoutBtn" class="btn-red">Logga ut</button>
+      <div class="header-meta">
+        <span id="userEmail" class="chip">…</span>
+        <button id="manageBillingBtn" class="btn ghost hide">Hantera</button>
+        <button id="upgradeBtn" class="btn primary">Uppgradera</button>
+        <button id="logoutBtn" class="btn danger">Logga ut</button>
       </div>
     </header>
 
-    <div id="freeBanner" class="banner hide">Gratisläge: <span id="usedCount">0</span>/20 spel använda. Du har <span id="leftCount">20</span> kvar.</div>
-
-    <!-- Projektpanel -->
-    <div class="panel">
-      <div class="controls">
-        <label>Projekt</label>
-        <select id="projectSelect" style="min-width:260px"></select>
-        <button id="newProjectBtn">Nytt projekt</button>
-        <button id="renameProjectBtn">Byt namn</button>
-        <button id="deleteProjectBtn" class="btn-red">Radera</button>
-      </div>
+    <div id="freeBanner" class="notice hide">
+      Gratisläge: <span id="usedCount">0</span>/20 spel använda. Du har <span id="leftCount">20</span> kvar.
     </div>
 
-    <!-- Flikar -->
-    <div class="tabs">
-      <div class="tab active" data-tab="reg">Registrera spel</div>
-      <div class="tab" data-tab="summary">Månadssummering</div>
-      <div class="tab" data-tab="list">Spel</div>
-    </div>
+    <main class="app-main">
+      <section class="primary">
+        <div class="top-board">
+          <section class="panel project-card">
+            <div class="project-header">
+              <div>
+                <span class="eyebrow">Aktivt projekt</span>
+                <h2 id="projectTitle" class="project-name">Inget projekt valt</h2>
+              </div>
+              <span class="count-chip"><span id="projectCount">0</span> projekt</span>
+            </div>
+            <div class="project-controls">
+              <label class="sr-only" for="projectSelect">Välj projekt</label>
+              <select id="projectSelect" aria-label="Välj projekt"></select>
+              <div class="project-buttons">
+                <button id="newProjectBtn" class="btn ghost" type="button">Nytt</button>
+                <button id="renameProjectBtn" class="btn ghost" type="button">Byt namn</button>
+                <button id="deleteProjectBtn" class="btn danger" type="button">Radera</button>
+              </div>
+            </div>
+          </section>
 
-    <!-- Registrera -->
-    <section id="tab-reg" class="panel">
-      <div class="grid">
-        <div class="col-2">
-          <label>Matchdag</label>
-          <input id="iDate" type="date" />
-        </div>
-        <div class="col-3">
-          <label>Match</label>
-          <input id="iMatch" type="text" placeholder="Arsenal — Chelsea" />
-        </div>
-        <div class="col-3">
-          <label>Marknad</label>
-          <input id="iMarket" type="text" placeholder="Över 8.5 frisparkar" />
-        </div>
-        <div class="col-2">
-          <label>Oddset</label>
-          <input id="iOdds" type="number" step="0.01" min="1.01" placeholder="1.85" />
-        </div>
-        <div class="col-1">
-          <label>Insats</label>
-          <input id="iStake" type="number" step="1" min="1" value="1"/>
-        </div>
-        <div class="col-1">
-          <label>Spelbolag</label>
-          <input id="iBook" type="text" placeholder="Bet365" />
+          <section class="panel stats-panel">
+            <div class="stats-heading">
+              <h2>Snabböversikt</h2>
+              <p class="muted">Uppdateras automatiskt för valt projekt.</p>
+            </div>
+            <div class="overview-grid">
+              <div class="overview-card">
+                <span class="label">Spel totalt</span>
+                <span id="quickTotal" class="value">0</span>
+              </div>
+              <div class="overview-card">
+                <span class="label">Pågående</span>
+                <span id="quickPending" class="value">0</span>
+              </div>
+              <div class="overview-card">
+                <span class="label">ROI</span>
+                <span id="quickRoi" class="value">–</span>
+              </div>
+              <div class="overview-card">
+                <span class="label">Profit</span>
+                <span id="quickProfit" class="value">0.00</span>
+              </div>
+            </div>
+          </section>
         </div>
 
-        <div class="col-2">
-          <label>Resultat</label>
-          <select id="iResult">
-            <option>Pending</option><option>Win</option><option>Loss</option><option>Void</option>
-          </select>
+        <div class="tabs" role="tablist">
+          <button class="tab active" data-tab="reg" role="tab" aria-selected="true">Registrera spel</button>
+          <button class="tab" data-tab="summary" role="tab" aria-selected="false">Månadssummering</button>
+          <button class="tab" data-tab="list" role="tab" aria-selected="false">Spel</button>
         </div>
-        <div class="col-6">
-          <label>Notering</label>
-          <input id="iNote" type="text" placeholder="Ex. sent mål, cashout, etc." />
-        </div>
-        <div class="col-4 actions" style="align-self:end">
-          <button id="addBetBtn" class="btn-green">Lägg till spel</button>
-          <button id="resetProjectBtn" class="btn-red">Nollställ projekt</button>
-        </div>
-      </div>
-    </section>
 
-    <!-- Månadssummering -->
-    <section id="tab-summary" class="panel hide">
-      <div class="controls">
-        <label>Månad (matchdag)</label>
-        <select id="monthFilter"></select>
-      </div>
+        <section id="tab-reg" class="panel tab-panel" role="tabpanel" aria-labelledby="Registrera spel">
+          <div class="form-grid">
+            <div class="col-3">
+              <label for="iDate">Matchdag</label>
+              <input id="iDate" type="date" />
+            </div>
+            <div class="col-4">
+              <label for="iMatch">Match</label>
+              <input id="iMatch" type="text" placeholder="Arsenal — Chelsea" />
+            </div>
+            <div class="col-3">
+              <label for="iMarket">Marknad</label>
+              <input id="iMarket" type="text" placeholder="Över 8.5 frisparkar" />
+            </div>
+            <div class="col-2">
+              <label for="iOdds">Oddset</label>
+              <input id="iOdds" type="number" step="0.01" min="1.01" placeholder="1.85" />
+            </div>
+            <div class="col-2">
+              <label for="iStake">Insats</label>
+              <input id="iStake" type="number" step="1" min="1" value="1" />
+            </div>
+            <div class="col-3">
+              <label for="iBook">Spelbolag</label>
+              <input id="iBook" type="text" placeholder="Bet365" />
+            </div>
+            <div class="col-3">
+              <label for="iResult">Resultat</label>
+              <select id="iResult">
+                <option>Pending</option>
+                <option>Win</option>
+                <option>Loss</option>
+                <option>Void</option>
+              </select>
+            </div>
+            <div class="col-6 form-actions">
+              <button id="cancelEditBtn" class="btn ghost hide" type="button">Avbryt redigering</button>
+              <button id="addBetBtn" class="btn primary" type="button">Lägg till spel</button>
+              <button id="resetProjectBtn" class="btn danger" type="button">Nollställ projekt</button>
+            </div>
+          </div>
+        </section>
 
-      <div class="stat">
-        <div class="panel"><div class="hint">Spel (avgjorda)</div><div id="sGames" style="font-size:22px;font-weight:800">0</div></div>
-        <div class="panel"><div class="hint">Win</div><div id="sWins" style="font-size:22px;font-weight:800">0</div></div>
-        <div class="panel"><div class="hint">Profit</div><div id="sProfit" style="font-size:22px;font-weight:800">0.00</div></div>
-        <div class="panel"><div class="hint">ROI</div><div id="sRoi" style="font-size:22px;font-weight:800">0.00%</div></div>
-      </div>
+        <section id="tab-summary" class="panel tab-panel hide" role="tabpanel" aria-labelledby="Månadssummering">
+          <div class="form-grid" style="margin-bottom: 16px;">
+            <div class="col-4">
+              <label for="monthFilter">Månad (matchdag)</label>
+              <select id="monthFilter"></select>
+            </div>
+          </div>
+          <div class="summary-grid">
+            <div class="summary-card">
+              <span class="label">Spel (avgjorda)</span>
+              <span id="sGames" class="value">0</span>
+            </div>
+            <div class="summary-card">
+              <span class="label">Vinster</span>
+              <span id="sWins" class="value">0</span>
+            </div>
+            <div class="summary-card">
+              <span class="label">Profit</span>
+              <span id="sProfit" class="value">0.00</span>
+            </div>
+            <div class="summary-card">
+              <span class="label">ROI</span>
+              <span id="sRoi" class="value">0.00%</span>
+            </div>
+          </div>
+          <div class="summary-meta" style="margin-top: 20px;">
+            <span class="label">Vald period</span>
+            <div id="sMonthName" class="value">Alla månader</div>
+          </div>
+        </section>
 
-      <div style="margin-top:10px">
-        <div class="panel">
-          <div class="hint">Månad</div>
-          <div id="sMonthName" style="font-weight:700">-</div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Spel -->
-    <section id="tab-list" class="panel hide">
-      <div id="playsContainer"></div>
-    </section>
+        <section id="tab-list" class="panel tab-panel hide" role="tabpanel" aria-labelledby="Spel">
+          <div id="playsContainer"></div>
+        </section>
+      </section>
+    </main>
   </div>
 
-<script type="module">
-  // ======= KONFIG =======
-  const SUPABASE_URL = "https://updpywjfxeahtjpelbku.supabase.co";
-  const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVwZHB5d2pmeGVhaHRqcGVsYmt1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY5MjQzOTcsImV4cCI6MjA3MjUwMDM5N30.i1ztG8dkcHFLq8WEn_uVrgCBk0_Wf5gZb_OQQuaSGgo";
+  <script type="module" src="./app.js"></script>
 
-  // ======= LIBS =======
-  import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/+esm";
-  const SB = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-
-  // ======= STATE =======
-  let currentUser = null;
-  let currentProject = null; // {id, name}
-  let projects = []; // [{id,name}]
-  let bets = [];     // alla bets för valt projekt
-
-  // ======= UI HELPERS =======
-  const $ = s => document.querySelector(s);
-  const $$ = s => document.querySelectorAll(s);
-  const fmtMoney = v => (Math.round(v * 100)/100).toFixed(2);
-  const svMonth = (y,m) => new Date(y, m-1, 1).toLocaleDateString("sv-SE",{month:"long",year:"numeric"});
-
-  function setTab(name){
-    $$(".tab").forEach(t => t.classList.toggle("active", t.dataset.tab===name));
-    $("#tab-reg").classList.toggle("hide", name!=="reg");
-    $("#tab-summary").classList.toggle("hide", name!=="summary");
-    $("#tab-list").classList.toggle("hide", name!=="list");
-  }
-
-  $$(".tab").forEach(t => t.addEventListener("click",()=>setTab(t.dataset.tab)));
-
-  // ======= AUTH =======
-  async function ensureProfileRow(){
-    if(!currentUser) return;
-    try{
-      const payload = { id: currentUser.id };
-      if(currentUser.email) payload.email = currentUser.email;
-      const { error } = await SB.from("users").upsert(payload, { onConflict: "id" });
-      if(error) console.error("Kunde inte skapa/uppdatera användarrad", error);
-    }catch(err){
-      console.error("ensureProfileRow fel", err);
-    }
-  }
-
-  async function ensureAuth(){
-    const { data: { session } } = await SB.auth.getSession();
-    if(!session){
-      location.href = "/login.html";
-      throw new Error("NOT_AUTHENTICATED");
-    }
-    currentUser = session.user;
-    $("#userEmail").textContent = currentUser.email || "Ingen e-post";
-    await ensureProfileRow();
-  }
-
-  $("#logoutBtn").onclick = async () => { await SB.auth.signOut(); location.href="/"; };
-
-  // ======= STRIPE KNAPPAR =======
-  async function callStripeCheckout(){
-    try{
-      const { data: { session } } = await SB.auth.getSession();
-      const u = session?.user;
-      if(!u?.id){
-        alert("Sessionen är ogiltig. Logga in igen.");
-        return;
-      }
-      currentUser = u;
-      await ensureProfileRow();
-      const r = await fetch("/api/create-checkout-session", {
-        method:"POST",
-        headers:{ "Content-Type": "application/json" },
-        body: JSON.stringify({ user_id: u?.id, email: u?.email })
-      });
-      const d = await r.json();
-      if(d?.url) location.href = d.url; else alert(d?.error || "Kunde inte starta Stripe Checkout");
-    }catch(e){ alert("Nätverksfel mot Stripe"); }
-  }
-  async function callBillingPortal(){
-    try{
-      const { data: { session } } = await SB.auth.getSession();
-      const u = session?.user;
-      if(!u?.id){
-        alert("Sessionen är ogiltig. Logga in igen.");
-        return;
-      }
-      currentUser = u;
-      await ensureProfileRow();
-      const r = await fetch("/api/create-portal-session", {
-        method:"POST",
-        headers:{ "Content-Type": "application/json" },
-        body: JSON.stringify({ user_id: u?.id })
-      });
-      const d = await r.json();
-      if(d?.url) location.href = d.url; else alert(d?.error || "Ingen portal hittades");
-    }catch(e){ alert("Nätverksfel mot Stripe"); }
-  }
-  $("#upgradeBtn").onclick = callStripeCheckout;
-  $("#manageBillingBtn").onclick = callBillingPortal;
-
-  // ======= DATA =======
-  async function loadProjects(){
-    const { data, error } = await SB.from("projects")
-      .select("id,name")
-      .eq("user_id", currentUser.id)
-      .order("created_at",{ascending:true});
-    if(error){ console.error(error); return; }
-    projects = data||[];
-    renderProjectSelect();
-  }
-
-  function renderProjectSelect(){
-    const sel = $("#projectSelect");
-    sel.innerHTML = "";
-    for(const p of projects){
-      const opt = document.createElement("option");
-      opt.value = p.id; opt.textContent = p.name;
-      sel.appendChild(opt);
-    }
-    if(projects.length && !currentProject){
-      currentProject = projects[0];
-      sel.value = currentProject.id;
-      loadBets();
-    }else if(currentProject){
-      sel.value = currentProject.id;
-    }
-  }
-
-  $("#projectSelect").onchange = ()=>{
-    const id = $("#projectSelect").value;
-    currentProject = projects.find(p=>p.id===id) || null;
-    loadBets();
-  };
-
-  $("#newProjectBtn").onclick = async ()=>{
-    const name = prompt("Namn på nytt projekt:", "Nytt projekt");
-    if(!name) return;
-    const { data, error } = await SB.from("projects")
-      .insert({ name, user_id: currentUser.id })
-      .select("id,name")
-      .single();
-    if(error){ alert("Kunde inte skapa projekt"); return; }
-    projects.push(data);
-    currentProject = data;
-    renderProjectSelect();
-    await loadBets();
-  };
-
-  $("#renameProjectBtn").onclick = async ()=>{
-    if(!currentProject) return;
-    const name = prompt("Nytt namn:", currentProject.name);
-    if(!name) return;
-    const { error } = await SB.from("projects")
-      .update({ name })
-      .eq("id", currentProject.id)
-      .eq("user_id", currentUser.id);
-    if(error){ alert("Kunde inte byta namn"); return; }
-    currentProject.name = name;
-    renderProjectSelect();
-  };
-
-  $("#deleteProjectBtn").onclick = async ()=>{
-    if(!currentProject) return;
-    if(!confirm("Radera projektet och alla spel?")) return;
-    const { error } = await SB.from("projects")
-      .delete()
-      .eq("id", currentProject.id)
-      .eq("user_id", currentUser.id);
-    if(error){ alert("Kunde inte radera"); return; }
-    projects = projects.filter(p=>p.id!==currentProject.id);
-    currentProject = projects[0] || null;
-    renderProjectSelect();
-    await loadBets();
-  };
-
-  $("#resetProjectBtn").onclick = async ()=>{
-    if(!currentProject) return;
-    if(!confirm("Ta bort alla spel i projektet?")) return;
-    const { error } = await SB.from("bets")
-      .delete()
-      .eq("project_id", currentProject.id)
-      .eq("user_id", currentUser.id);
-    if(error){ alert("Kunde inte nollställa"); return; }
-    await loadBets();
-  };
-
-  async function loadBets(){
-    if(!currentProject){
-      $("#playsContainer").innerHTML="";
-      await updateFreeBanner();
-      return;
-    }
-    const { data, error } = await SB.from("bets")
-      .select("*")
-      .eq("project_id", currentProject.id)
-      .eq("user_id", currentUser.id)
-      .order("matchday",{ascending:false})
-      .order("created_at",{ascending:false});
-    if(error){ console.error(error); return; }
-    bets = data||[];
-    renderBets();
-    renderSummary();
-    await updateFreeBanner();
-  }
-
-  async function updateFreeBanner(){
-    if(!currentUser) return;
-    try{
-      const addBtn = $("#addBetBtn");
-      const { data: profile, error: profileErr } = await SB
-        .from("users")
-        .select("is_premium")
-        .eq("id", currentUser.id)
-        .maybeSingle();
-      if(profileErr) throw profileErr;
-      if(!profile){
-        await ensureProfileRow();
-      }
-
-      const premium = !!profile?.is_premium;
-      if(premium){
-        $("#freeBanner").classList.add("hide");
-        $("#upgradeBtn").classList.add("hide");
-        $("#manageBillingBtn").classList.remove("hide");
-        if(addBtn) addBtn.disabled = false;
-        return;
-      }
-
-      const { count, error: countErr } = await SB.from("bets")
-        .select("id", { count: "exact", head: true })
-        .eq("user_id", currentUser.id);
-      if(countErr) throw countErr;
-
-      const used = count || 0;
-      const left = Math.max(0, 20 - used);
-      $("#usedCount").textContent = used;
-      $("#leftCount").textContent = left;
-      $("#freeBanner").classList.toggle("hide", false);
-      $("#upgradeBtn").classList.remove("hide");
-      $("#manageBillingBtn").classList.add("hide");
-      if(addBtn) addBtn.disabled = left <= 0;
-    }catch(err){
-      console.error("updateFreeBanner fel", err);
-      $("#freeBanner").classList.add("hide");
-      $("#upgradeBtn").classList.remove("hide");
-      $("#manageBillingBtn").classList.add("hide");
-      const addBtn = $("#addBetBtn");
-      if(addBtn) addBtn.disabled = false;
-    }
-  }
-
-  // ======= LÄGG TILL SPEL =======
-  $("#addBetBtn").onclick = async ()=>{
-    if(!currentProject) return alert("Välj/skapa projekt först.");
-    const d = $("#iDate").value;
-    const match = $("#iMatch").value.trim();
-    const market = $("#iMarket").value.trim();
-    const odds = parseFloat($("#iOdds").value);
-    const stake = parseFloat($("#iStake").value||"1");
-    const book = $("#iBook").value.trim();
-    const result = $("#iResult").value;
-    const note = $("#iNote").value.trim();
-
-    if(!d || !match || !market || !odds || !stake) return alert("Fyll i alla fält.");
-
-    if($("#addBetBtn").disabled){
-      alert("Du har använt alla 20 gratis spel. Uppgradera för fler.");
-      return;
-    }
-
-    const { error } = await SB.from("bets").insert({
-      project_id: currentProject.id,
-      user_id: currentUser.id,
-      matchday: d,
-      match, market, odds, stake, book, result, note
-    });
-    if(error){ alert("Kunde inte spara spel"); return; }
-
-    $("#iNote").value = "";
-    await loadBets();
-    setTab("list");
-  };
-
-  // ======= RENDER LISTA (gruppera per månad) =======
-  function renderBets(){
-    const byMonth = {};
-    for(const b of bets){
-      if(!b.matchday) continue;
-      const ym = b.matchday.slice(0,7); // YYYY-MM
-      (byMonth[ym] ||= []).push(b);
-    }
-    const cont = $("#playsContainer");
-    cont.innerHTML = "";
-
-    if(bets.length === 0){
-      cont.innerHTML = '<p class="hint">Inga spel registrerade ännu. Lägg till ditt första spel ovan.</p>';
-      return;
-    }
-
-    Object.keys(byMonth).sort().reverse().forEach(ym=>{
-      const arr = byMonth[ym];
-      const [y,m] = ym.split("-").map(Number);
-      const el = document.createElement("details");
-      el.className = "month"; el.open = false;
-      el.innerHTML = `<summary>${svMonth(y,m)} (${arr.length} spel)</summary>`;
-
-      const header = document.createElement("div");
-      header.className = "row hint";
-      header.innerHTML = `
-        <div>Datum</div><div>Match</div><div>Marknad</div>
-        <div>Odds</div><div>Insats</div><div>Spelbolag</div>
-        <div>Notering</div><div>Resultat</div>`;
-      el.appendChild(header);
-
-      for(const b of arr){
-        const row = document.createElement("div"); row.className="row";
-        const resHtml = `
-          <div class="actions">
-            <span class="pill win" data-r="Win">Win</span>
-            <span class="pill loss" data-r="Loss">Loss</span>
-            <span class="pill pending" data-r="Pending">Pending</span>
-            <span class="pill void" data-r="Void">Void</span>
-            <span class="pill" data-del="1" style="margin-left:6px">Ta bort</span>
-          </div>`;
-        row.innerHTML = `
-          <div>${b.matchday}</div>
-          <div>${b.match}</div>
-          <div>${b.market}</div>
-          <div>${b.odds}</div>
-          <div>${b.stake}</div>
-          <div>${b.book||""}</div>
-          <div>${b.note||""}</div>
-          <div>${resHtml}</div>
-        `;
-        // klickar på snabbknappar
-        row.querySelectorAll(".pill").forEach(p=>{
-          p.onclick = async ()=>{
-            if(p.dataset.del){
-              if(confirm("Ta bort spelet?")){
-                await SB.from("bets")
-                  .delete()
-                  .eq("id", b.id)
-                  .eq("user_id", currentUser.id);
-                await loadBets();
-              }
-            }else{
-              await SB.from("bets")
-                .update({ result: p.dataset.r })
-                .eq("id", b.id)
-                .eq("user_id", currentUser.id);
-              await loadBets();
-            }
-          };
-        });
-        el.appendChild(row);
-      }
-      cont.appendChild(el);
-    });
-  }
-
-  // ======= RENDER MÅNADSSUMMERING =======
-  function recompute(monthFilter="all"){
-    let data = bets;
-    if(monthFilter!=="all"){
-      data = data.filter(b => b.matchday?.startsWith(monthFilter));
-    }
-    const decided = data.filter(b => b.result!=="Pending" && b.result!=="Void");
-    const wins = decided.filter(b => b.result==="Win").length;
-    const stakeSum = decided.reduce((s,b)=>s+b.stake,0);
-    const profit = decided.reduce((s,b)=> s + (b.result==="Win" ? (b.odds-1)*b.stake : -b.stake), 0);
-    const roi = stakeSum>0 ? (profit/stakeSum)*100 : 0;
-
-    $("#sGames").textContent = decided.length.toString();
-    $("#sWins").textContent = wins.toString();
-    $("#sProfit").textContent = fmtMoney(profit);
-    $("#sRoi").textContent = fmtMoney(roi)+"%";
-
-    if(monthFilter==="all"){ $("#sMonthName").textContent = "Alla månader"; }
-    else{
-      const [y,m] = monthFilter.split("-").map(Number);
-      $("#sMonthName").textContent = svMonth(y,m);
-    }
-  }
-
-  function renderSummary(){
-    // fyll månadsväljare
-    const months = [...new Set(bets.filter(b=>b.matchday).map(b=>b.matchday.slice(0,7)))].sort().reverse();
-    const sel = $("#monthFilter");
-    sel.innerHTML = `<option value="all">Alla månader</option>` + months.map(m=>`<option value="${m}">${m}</option>`).join("");
-    sel.onchange = ()=>recompute(sel.value);
-    recompute(sel.value||"all");
-  }
-
-  // ======= INIT =======
-  (async function init(){
-    try{
-      await ensureAuth();
-    }catch(err){
-      console.warn("Användaren är inte inloggad", err);
-      return;
-    }
-
-    // förifyll dagens datum
-    $("#iDate").valueAsDate = new Date();
-
-    await loadProjects();
-    if(!currentProject) await updateFreeBanner();
-  })();
-</script>
 </body>
 </html>

--- a/app.js
+++ b/app.js
@@ -1,0 +1,637 @@
+// Section: Bibliotek
+import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/+esm";
+
+// Section: Konfiguration
+const SUPABASE_URL = "https://updpywjfxeahtjpelbku.supabase.co";
+const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVwZHB5d2pmeGVhaHRqcGVsYmt1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY5MjQzOTcsImV4cCI6MjA3MjUwMDM5N30.i1ztG8dkcHFLq8WEn_uVrgCBk0_Wf5gZb_OQQuaSGgo";
+
+const SB = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+// Section: Tillstånd
+let currentUser = null;
+let currentProject = null; // {id, name}
+let projects = []; // [{id,name}]
+let bets = [];     // alla bets för valt projekt
+let editingBetId = null;
+
+// Section: UI-hjälpare
+const $ = s => document.querySelector(s);
+const $$ = s => document.querySelectorAll(s);
+const fmtMoney = v => (Math.round(v * 100)/100).toFixed(2);
+const svMonth = (y,m) => new Date(y, m-1, 1).toLocaleDateString("sv-SE",{month:"long",year:"numeric"});
+
+function setTab(name){
+  $$(".tab").forEach(t => {
+    const active = t.dataset.tab === name;
+    t.classList.toggle("active", active);
+    t.setAttribute("aria-selected", active ? "true" : "false");
+  });
+  const reg = $("#tab-reg");
+  const summary = $("#tab-summary");
+  const list = $("#tab-list");
+  if(reg){ reg.classList.toggle("hide", name!=="reg"); reg.setAttribute("aria-hidden", name!=="reg"); }
+  if(summary){ summary.classList.toggle("hide", name!=="summary"); summary.setAttribute("aria-hidden", name!=="summary"); }
+  if(list){ list.classList.toggle("hide", name!=="list"); list.setAttribute("aria-hidden", name!=="list"); }
+}
+
+$$(".tab").forEach(t => t.addEventListener("click",()=>setTab(t.dataset.tab)));
+
+function closeActionMenus(){
+  document.querySelectorAll(".action-dropdown.open").forEach(el => {
+    el.classList.remove("open");
+    const toggle = el.querySelector(".dropdown-toggle");
+    if(toggle){
+      toggle.setAttribute("aria-expanded", "false");
+    }
+  });
+  document
+    .querySelectorAll('.dropdown-toggle[aria-expanded="true"]')
+    .forEach(btn => btn.setAttribute("aria-expanded", "false"));
+}
+
+function resetBetForm(){
+  const today = new Date();
+  today.setHours(0,0,0,0);
+  const dateInput = $("#iDate");
+  if(dateInput) dateInput.valueAsDate = today;
+  const matchInput = $("#iMatch");
+  if(matchInput) matchInput.value = "";
+  const marketInput = $("#iMarket");
+  if(marketInput) marketInput.value = "";
+  const oddsInput = $("#iOdds");
+  if(oddsInput) oddsInput.value = "";
+  const stakeInput = $("#iStake");
+  if(stakeInput) stakeInput.value = "1";
+  const bookInput = $("#iBook");
+  if(bookInput) bookInput.value = "";
+  const resultSelect = $("#iResult");
+  if(resultSelect) resultSelect.value = "Pending";
+  editingBetId = null;
+  const addBtn = $("#addBetBtn");
+  if(addBtn) addBtn.textContent = "Lägg till spel";
+  const cancelBtn = $("#cancelEditBtn");
+  if(cancelBtn) cancelBtn.classList.add("hide");
+}
+
+function startEdit(bet){
+  editingBetId = bet.id;
+  const dateInput = $("#iDate");
+  if(dateInput) dateInput.value = bet.matchday ? bet.matchday.slice(0,10) : "";
+  const matchInput = $("#iMatch");
+  if(matchInput) matchInput.value = bet.match || "";
+  const marketInput = $("#iMarket");
+  if(marketInput) marketInput.value = bet.market || "";
+  const oddsInput = $("#iOdds");
+  if(oddsInput){
+    const oddsNum = parseFloat(bet.odds);
+    oddsInput.value = Number.isFinite(oddsNum) ? oddsNum : "";
+  }
+  const stakeInput = $("#iStake");
+  if(stakeInput){
+    const stakeNum = parseFloat(bet.stake);
+    stakeInput.value = Number.isFinite(stakeNum) ? stakeNum : "1";
+  }
+  const bookInput = $("#iBook");
+  if(bookInput) bookInput.value = bet.book || "";
+  const resultSelect = $("#iResult");
+  if(resultSelect) resultSelect.value = bet.result || "Pending";
+  const addBtn = $("#addBetBtn");
+  if(addBtn) addBtn.textContent = "Spara spel";
+  const cancelBtn = $("#cancelEditBtn");
+  if(cancelBtn) cancelBtn.classList.remove("hide");
+  setTab("reg");
+  closeActionMenus();
+}
+
+document.addEventListener("click", closeActionMenus);
+document.addEventListener("keydown", ev => {
+  if(ev.key === "Escape"){
+    closeActionMenus();
+  }
+});
+
+// Section: Auth
+async function ensureProfileRow(){
+  if(!currentUser) return;
+  try{
+    const payload = { id: currentUser.id };
+    if(currentUser.email) payload.email = currentUser.email;
+    const { error } = await SB.from("users").upsert(payload, { onConflict: "id" });
+    if(error) console.error("Kunde inte skapa/uppdatera användarrad", error);
+  }catch(err){
+    console.error("ensureProfileRow fel", err);
+  }
+}
+
+async function ensureAuth(){
+  const { data: { session } } = await SB.auth.getSession();
+  if(!session){
+    location.href = "/login.html";
+    throw new Error("NOT_AUTHENTICATED");
+  }
+  currentUser = session.user;
+  $("#userEmail").textContent = currentUser.email || "Ingen e-post";
+  await ensureProfileRow();
+}
+
+$("#logoutBtn").onclick = async () => { await SB.auth.signOut(); location.href="/"; };
+
+// Section: Stripe-knappar
+async function callStripeCheckout(){
+  try{
+    const { data: { session } } = await SB.auth.getSession();
+    const u = session?.user;
+    if(!u?.id){
+      alert("Sessionen är ogiltig. Logga in igen.");
+      return;
+    }
+    currentUser = u;
+    await ensureProfileRow();
+    const r = await fetch("/api/create-checkout-session", {
+      method:"POST",
+      headers:{ "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: u?.id, email: u?.email })
+    });
+    const d = await r.json();
+    if(d?.url) location.href = d.url; else alert(d?.error || "Kunde inte starta Stripe Checkout");
+  }catch(e){ alert("Nätverksfel mot Stripe"); }
+}
+async function callBillingPortal(){
+  try{
+    const { data: { session } } = await SB.auth.getSession();
+    const u = session?.user;
+    if(!u?.id){
+      alert("Sessionen är ogiltig. Logga in igen.");
+      return;
+    }
+    currentUser = u;
+    await ensureProfileRow();
+    const r = await fetch("/api/create-portal-session", {
+      method:"POST",
+      headers:{ "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: u?.id })
+    });
+    const d = await r.json();
+    if(d?.url) location.href = d.url; else alert(d?.error || "Ingen portal hittades");
+  }catch(e){ alert("Nätverksfel mot Stripe"); }
+}
+const upgradeBtnEl = $("#upgradeBtn");
+if(upgradeBtnEl){
+  upgradeBtnEl.dataset.mode = "upgrade";
+  upgradeBtnEl.addEventListener("click", ()=>{
+    if(upgradeBtnEl.dataset.mode === "manage"){
+      callBillingPortal();
+    }else{
+      callStripeCheckout();
+    }
+  });
+}
+const manageBillingBtnEl = $("#manageBillingBtn");
+if(manageBillingBtnEl){
+  manageBillingBtnEl.addEventListener("click", callBillingPortal);
+}
+
+// Section: Datahämtning
+async function loadProjects(){
+  const { data, error } = await SB.from("projects")
+    .select("id,name")
+    .eq("user_id", currentUser.id)
+    .order("created_at",{ascending:true});
+  if(error){ console.error(error); return; }
+  projects = data||[];
+  renderProjectSelect();
+}
+
+function renderProjectSelect(){
+  const sel = $("#projectSelect");
+  if(!sel) return;
+  sel.innerHTML = "";
+  for(const p of projects){
+    const opt = document.createElement("option");
+    opt.value = p.id; opt.textContent = p.name;
+    sel.appendChild(opt);
+  }
+  if(projects.length && !currentProject){
+    currentProject = projects[0];
+    sel.value = currentProject.id;
+    loadBets();
+  }else if(currentProject){
+    sel.value = currentProject.id;
+  }
+  updateProjectMeta();
+}
+
+function updateProjectMeta(){
+  const title = $("#projectTitle");
+  if(title) title.textContent = currentProject?.name || "Inget projekt valt";
+  const count = $("#projectCount");
+  if(count) count.textContent = projects.length.toString();
+}
+
+$("#projectSelect").onchange = ()=>{
+  const id = $("#projectSelect").value;
+  currentProject = projects.find(p=>p.id===id) || null;
+  loadBets();
+};
+
+$("#newProjectBtn").onclick = async ()=>{
+  const name = prompt("Namn på nytt projekt:", "Nytt projekt");
+  if(!name) return;
+  const { data, error } = await SB.from("projects")
+    .insert({ name, user_id: currentUser.id })
+    .select("id,name")
+    .single();
+  if(error){ alert("Kunde inte skapa projekt"); return; }
+  projects.push(data);
+  currentProject = data;
+  renderProjectSelect();
+  await loadBets();
+};
+
+$("#renameProjectBtn").onclick = async ()=>{
+  if(!currentProject) return;
+  const name = prompt("Nytt namn:", currentProject.name);
+  if(!name) return;
+  const { error } = await SB.from("projects")
+    .update({ name })
+    .eq("id", currentProject.id)
+    .eq("user_id", currentUser.id);
+  if(error){ alert("Kunde inte byta namn"); return; }
+  currentProject.name = name;
+  renderProjectSelect();
+};
+
+$("#deleteProjectBtn").onclick = async ()=>{
+  if(!currentProject) return;
+  if(!confirm("Radera projektet och alla spel?")) return;
+  const { error } = await SB.from("projects")
+    .delete()
+    .eq("id", currentProject.id)
+    .eq("user_id", currentUser.id);
+  if(error){ alert("Kunde inte radera"); return; }
+  projects = projects.filter(p=>p.id!==currentProject.id);
+  currentProject = projects[0] || null;
+  renderProjectSelect();
+  await loadBets();
+};
+
+$("#cancelEditBtn").onclick = ()=> resetBetForm();
+
+$("#resetProjectBtn").onclick = async ()=>{
+  if(!currentProject) return;
+  if(!confirm("Ta bort alla spel i projektet?")) return;
+  const { error } = await SB.from("bets")
+    .delete()
+    .eq("project_id", currentProject.id)
+    .eq("user_id", currentUser.id);
+  if(error){ alert("Kunde inte nollställa"); return; }
+  await loadBets();
+};
+
+async function loadBets(){
+  closeActionMenus();
+  resetBetForm();
+  updateProjectMeta();
+  const cont = $("#playsContainer");
+  if(!currentProject){
+    bets = [];
+    if(cont) cont.innerHTML = '<div class="empty-state">Välj eller skapa ett projekt för att börja registrera spel.</div>';
+    renderSummary();
+    await updateFreeBanner();
+    return;
+  }
+  const { data, error } = await SB.from("bets")
+    .select("*")
+    .eq("project_id", currentProject.id)
+    .eq("user_id", currentUser.id)
+    .order("matchday",{ascending:false})
+    .order("created_at",{ascending:false});
+  if(error){ console.error(error); return; }
+  bets = data||[];
+  renderBets();
+  renderSummary();
+  await updateFreeBanner();
+}
+
+async function updateFreeBanner(){
+  if(!currentUser) return;
+  try{
+    const addBtn = $("#addBetBtn");
+    const { data: profile, error: profileErr } = await SB
+      .from("users")
+      .select("plan_tier, free_bets_used, is_premium")
+      .eq("id", currentUser.id)
+      .maybeSingle();
+    if(profileErr){ console.error(profileErr); return; }
+    const banner = $("#freeBanner");
+    if(!banner) return;
+    const manageBtn = $("#manageBillingBtn");
+    const upgradeBtn = $("#upgradeBtn");
+    const isPremium = Boolean(profile?.is_premium);
+    const used = Number(profile?.free_bets_used) || 0;
+    const left = Math.max(20 - used, 0);
+    $("#usedCount").textContent = used.toString();
+    $("#leftCount").textContent = left.toString();
+    if(isPremium){
+      banner.classList.add("hide");
+      if(manageBtn) manageBtn.classList.remove("hide");
+      if(upgradeBtn){
+        upgradeBtn.textContent = "Hantera";
+        upgradeBtn.dataset.mode = "manage";
+      }
+      if(addBtn) addBtn.disabled = false;
+    }else{
+      banner.classList.remove("hide");
+      if(manageBtn) manageBtn.classList.add("hide");
+      if(upgradeBtn){
+        upgradeBtn.textContent = "Uppgradera";
+        upgradeBtn.dataset.mode = "upgrade";
+      }
+      if(addBtn) addBtn.disabled = used >= 20;
+    }
+  }catch(err){
+    console.error("Kunde inte hämta profil", err);
+    const addBtn = $("#addBetBtn");
+    if(addBtn) addBtn.disabled = false;
+  }
+}
+
+// Section: Lägg till spel
+$("#addBetBtn").onclick = async ()=>{
+  if(!currentProject) return alert("Välj/skapa projekt först.");
+  const d = $("#iDate").value;
+  const match = $("#iMatch").value.trim();
+  const market = $("#iMarket").value.trim();
+  const odds = parseFloat($("#iOdds").value);
+  const stake = parseFloat($("#iStake").value);
+  const book = $("#iBook").value.trim();
+  const result = $("#iResult").value;
+
+  if(!d || !match){
+    alert("Ange matchdag och match.");
+    return;
+  }
+  if(!Number.isFinite(odds) || odds <= 1){
+    alert("Ange ett giltigt odds (större än 1.00).");
+    return;
+  }
+  if(!Number.isFinite(stake) || stake <= 0){
+    alert("Ange en giltig insats.");
+    return;
+  }
+
+  const addBtn = $("#addBetBtn");
+  if(!editingBetId && addBtn?.disabled){
+    alert("Du har använt alla 20 gratis spel. Uppgradera för fler.");
+    return;
+  }
+
+  const payload = {
+    project_id: currentProject.id,
+    user_id: currentUser.id,
+    matchday: d,
+    match,
+    market: market || null,
+    odds,
+    stake,
+    book: book || null,
+    result
+  };
+
+  if(editingBetId){
+    const { error } = await SB.from("bets")
+      .update(payload)
+      .eq("id", editingBetId)
+      .eq("user_id", currentUser.id);
+    if(error){ alert("Kunde inte uppdatera spel"); return; }
+  }else{
+    const { error } = await SB.from("bets").insert(payload);
+    if(error){ alert("Kunde inte spara spel"); return; }
+  }
+
+  resetBetForm();
+  await loadBets();
+  setTab("list");
+};
+
+// Section: Rendera lista (grupperad per månad)
+function renderBets(){
+  const byMonth = {};
+  for(const b of bets){
+    if(!b.matchday) continue;
+    const ym = b.matchday.slice(0,7); // YYYY-MM
+    (byMonth[ym] ||= []).push(b);
+  }
+  const cont = $("#playsContainer");
+  if(!cont) return;
+  cont.innerHTML = "";
+
+  if(!bets.length){
+    cont.innerHTML = '<div class="empty-state">Inga spel registrerade ännu. Lägg till ditt första spel via formuläret till vänster.</div>';
+    return;
+  }
+
+  const formatNumber = (value, decimals = 2) => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num.toFixed(decimals) : "–";
+  };
+  const formatStake = value => {
+    const num = Number(value);
+    if(!Number.isFinite(num)) return "–";
+    return Number.isInteger(num) ? num.toString() : num.toFixed(2);
+  };
+
+  Object.keys(byMonth).sort().reverse().forEach(ym=>{
+    const arr = byMonth[ym];
+    const [y,m] = ym.split("-").map(Number);
+    const el = document.createElement("details");
+    el.className = "month"; el.open = false;
+    el.innerHTML = `<summary>${svMonth(y,m)}<span class="month-count">${arr.length} spel</span></summary>`;
+
+    const header = document.createElement("div");
+    header.className = "row row-head";
+    header.innerHTML = `
+      <div>Datum</div><div>Match &amp; Marknad</div><div>Odds</div>
+      <div>Insats</div><div>Spelbolag</div><div>Status &amp; åtgärder</div>`;
+    el.appendChild(header);
+
+    for(const b of arr){
+      const row = document.createElement("div"); row.className="row";
+      const matchInfo = `${b.match || "–"}`;
+      const marketInfo = b.market ? `<span class="market">${b.market}</span>` : "";
+      const book = b.book ? b.book : "–";
+      const status = b.result || "Pending";
+      const statusClass = status.toLowerCase();
+      const statusLabelMap = { Win: "Vinst", Loss: "Förlust", Pending: "Avvaktar", Void: "Void" };
+      const statusLabel = statusLabelMap[status] || status;
+      const fallbackId = Math.random().toString(36).slice(2, 9);
+      const menuId = b.id ? `actions-${b.id}` : `actions-temp-${fallbackId}`;
+      const resHtml = `
+        <div class="result-cell">
+          <span class="status-badge ${statusClass}">${statusLabel}</span>
+          <div class="action-dropdown">
+            <button type="button" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="${menuId}">Hantera</button>
+            <div class="action-menu" id="${menuId}" role="menu">
+              <button type="button" role="menuitem" data-action="status" data-value="Win">Markera som vinst</button>
+              <button type="button" role="menuitem" data-action="status" data-value="Loss">Markera som förlust</button>
+              <button type="button" role="menuitem" data-action="status" data-value="Pending">Markera som avvaktar</button>
+              <button type="button" role="menuitem" data-action="status" data-value="Void">Markera som void</button>
+              <button type="button" role="menuitem" data-action="edit">Redigera</button>
+              <button type="button" role="menuitem" data-action="delete">Ta bort</button>
+            </div>
+          </div>
+        </div>`;
+
+      row.innerHTML = `
+        <div>${b.matchday ? new Date(b.matchday).toLocaleDateString("sv-SE") : "–"}</div>
+        <div>${matchInfo}${marketInfo}</div>
+        <div>${formatNumber(b.odds)}</div>
+        <div>${formatStake(b.stake)}</div>
+        <div>${book}</div>
+        <div>${resHtml}</div>`;
+
+      const dropdown = row.querySelector(".action-dropdown");
+      const toggle = dropdown?.querySelector(".dropdown-toggle");
+      const menu = dropdown?.querySelector(".action-menu");
+      if(dropdown && toggle && menu){
+        toggle.addEventListener("click", ev => {
+          ev.stopPropagation();
+          closeActionMenus();
+          dropdown.classList.add("open");
+          toggle.setAttribute("aria-expanded", "true");
+          const firstItem = menu.querySelector("button");
+          if(firstItem){
+            setTimeout(()=>firstItem.focus(), 0);
+          }
+        });
+
+        menu.querySelectorAll("button").forEach(btn => {
+          btn.addEventListener("click", async ev => {
+            ev.stopPropagation();
+            const action = btn.dataset.action;
+            if(action === "edit"){ startEdit(b); }
+            if(action === "status"){
+              const value = btn.dataset.value;
+              if(value && value !== b.result){
+                const { error } = await SB.from("bets")
+                  .update({ result: value })
+                  .eq("id", b.id)
+                  .eq("user_id", currentUser.id);
+                if(error){ alert("Kunde inte uppdatera status"); }
+                else await loadBets();
+              }
+            }
+            if(action === "delete"){
+              if(confirm("Ta bort detta spel?")){
+                const { error } = await SB.from("bets")
+                  .delete()
+                  .eq("id", b.id)
+                  .eq("user_id", currentUser.id);
+                if(error){ alert("Kunde inte ta bort spel"); }
+                else await loadBets();
+              }
+            }
+            closeActionMenus();
+          });
+        });
+      }
+      el.appendChild(row);
+    }
+    cont.appendChild(el);
+  });
+}
+
+function renderQuickStats(){
+  const totalEl = $("#quickTotal");
+  if(!totalEl) return;
+  const total = bets.length;
+  const pending = bets.filter(b => b.result === "Pending").length;
+  const decided = bets.filter(b => b.result !== "Pending" && b.result !== "Void");
+  const profit = bets.reduce((sum, b) => {
+    const stakeNum = Number(b.stake);
+    if(!Number.isFinite(stakeNum)) return sum;
+    if(b.result === "Win"){
+      const oddsNum = Number(b.odds);
+      return Number.isFinite(oddsNum) ? sum + (oddsNum - 1) * stakeNum : sum;
+    }
+    if(b.result === "Loss"){
+      return sum - stakeNum;
+    }
+    return sum;
+  }, 0);
+  const stakeSum = decided.reduce((sum,b)=>{
+    const stakeNum = Number(b.stake);
+    return Number.isFinite(stakeNum) ? sum + stakeNum : sum;
+  },0);
+  const roi = stakeSum > 0 ? (profit / stakeSum) * 100 : null;
+
+  totalEl.textContent = total.toString();
+  const pendingEl = $("#quickPending");
+  if(pendingEl) pendingEl.textContent = pending.toString();
+  const roiEl = $("#quickRoi");
+  if(roiEl) roiEl.textContent = roi === null ? "–" : `${fmtMoney(roi)}%`;
+  const profitEl = $("#quickProfit");
+  if(profitEl) profitEl.textContent = fmtMoney(profit);
+}
+
+function recompute(monthFilter="all"){
+  let data = bets;
+  if(monthFilter!=="all"){
+    data = data.filter(b => b.matchday?.startsWith(monthFilter));
+  }
+  const decided = data.filter(b => b.result!=="Pending" && b.result!=="Void");
+  const wins = decided.filter(b => b.result==="Win").length;
+  const stakeSum = decided.reduce((s,b)=>{
+    const stakeNum = Number(b.stake);
+    return Number.isFinite(stakeNum) ? s + stakeNum : s;
+  },0);
+  const profit = decided.reduce((s,b)=>{
+    const stakeNum = Number(b.stake);
+    if(!Number.isFinite(stakeNum)) return s;
+    if(b.result==="Win"){
+      const oddsNum = Number(b.odds);
+      return Number.isFinite(oddsNum) ? s + (oddsNum-1)*stakeNum : s;
+    }
+    if(b.result==="Loss"){
+      return s - stakeNum;
+    }
+    return s;
+  }, 0);
+  const roi = stakeSum>0 ? (profit/stakeSum)*100 : 0;
+
+  $("#sGames").textContent = decided.length.toString();
+  $("#sWins").textContent = wins.toString();
+  $("#sProfit").textContent = fmtMoney(profit);
+  $("#sRoi").textContent = fmtMoney(roi)+"%";
+
+  if(monthFilter==="all"){ $("#sMonthName").textContent = "Alla månader"; }
+  else{
+    const [y,m] = monthFilter.split("-").map(Number);
+    $("#sMonthName").textContent = svMonth(y,m);
+  }
+}
+
+function renderSummary(){
+  const months = [...new Set(bets.filter(b=>b.matchday).map(b=>b.matchday.slice(0,7)))].sort().reverse();
+  const sel = $("#monthFilter");
+  if(!sel) return;
+  sel.innerHTML = `<option value="all">Alla månader</option>` + months.map(m=>`<option value="${m}">${m}</option>`).join("");
+  sel.onchange = ()=>recompute(sel.value);
+  recompute(sel.value||"all");
+  renderQuickStats();
+}
+
+// Section: Initiering
+(async function init(){
+  try{
+    await ensureAuth();
+  }catch(err){
+    console.warn("Användaren är inte inloggad", err);
+    return;
+  }
+
+  resetBetForm();
+
+  await loadProjects();
+  if(!currentProject) await updateFreeBanner();
+})();


### PR DESCRIPTION
## Summary
- place the project selector and quick stats inside a shared top board so the dashboard no longer duplicates the sidebar content
- add supporting styles for the new board, project header, and responsive breakpoints to keep the layout compact on all screen sizes

## Testing
- node --check app.js
- node --check api/stripe-webhook.js

------
https://chatgpt.com/codex/tasks/task_e_68c88467640c832ba150a53580cec558