### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -5,6 +5,12 @@ export const metadata = {
   description: 'Logga dina spel och följ din ROI med BetSpread.',
 };
 
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+};
+
 export default function RootLayout({ children }) {
   return (
     <html lang="sv">

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -630,6 +630,34 @@
     padding: 80px 6vw 48px;
   }
 
+  .heroInner {
+    justify-items: center;
+    text-align: center;
+    gap: 36px;
+  }
+
+  .heroCopy {
+    max-width: 520px;
+    width: 100%;
+  }
+
+  .heroHighlights {
+    justify-items: center;
+  }
+
+  .heroMockup {
+    width: 100%;
+  }
+
+  .mockupCardSecondary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .mockupTags {
+    flex-wrap: wrap;
+  }
+
   .workflowStep {
     grid-template-columns: 1fr;
   }
@@ -646,8 +674,33 @@
 }
 
 @media (max-width: 520px) {
+  .landingTopbar {
+    justify-content: center;
+  }
+
+  .brand {
+    width: 100%;
+    text-align: center;
+  }
+
+  .nav {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .navLink {
+    flex: 1 1 calc(50% - 10px);
+    text-align: center;
+  }
+
+  .heroCopy {
+    text-align: center;
+  }
+
   .heroHighlights li {
     font-size: 14px;
+    justify-content: center;
+    text-align: left;
   }
 
   .ctaRow {


### PR DESCRIPTION
## Summary
- add viewport metadata so the landing page scales correctly on mobile devices
- adjust landing page layout styles for small screens to prevent overflow and center hero content
- add a basic ESLint configuration to enable non-interactive linting

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6f3d4f44832b99c8f90826ba95a6