### PR TITLE
Improve landing page mobile support

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -5,6 +5,11 @@ export const metadata = {
   description: 'Logga dina spel och följ din ROI med BetSpread.',
 };
 
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
+
 export default function RootLayout({ children }) {
   return (
     <html lang="sv">

--- a/app/page.js
+++ b/app/page.js
@@ -1,4 +1,7 @@
+'use client';
+
 import Link from 'next/link';
+import { useState } from 'react';
 import styles from './page.module.css';
 
 const navLinks = [
@@ -119,24 +122,62 @@ const faqs = [
 const yearNow = new Date().getFullYear();
 
 export default function LandingPage() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const toggleMenu = () => setMenuOpen((prev) => !prev);
+  const closeMenu = () => setMenuOpen(false);
+  const navGroupClassName = menuOpen
+    ? `${styles.topbarNavGroup} ${styles.navGroupOpen}`
+    : styles.topbarNavGroup;
+
   return (
     <>
       <header className={styles.landingTopbar}>
         <div className={styles.brand}>BetSpread</div>
-        <nav className={styles.nav} aria-label="Primär">
-          {navLinks.map((link) => (
-            <Link key={link.href} href={link.href} className={styles.navLink}>
-              {link.label}
+        <button
+          type="button"
+          className={styles.mobileMenuButton}
+          onClick={toggleMenu}
+          aria-expanded={menuOpen}
+          aria-controls="primary-navigation"
+          data-open={menuOpen}
+        >
+          <span className={styles.menuIcon} aria-hidden="true">
+            <span />
+            <span />
+            <span />
+          </span>
+          <span>{menuOpen ? 'Stäng meny' : 'Meny'}</span>
+        </button>
+        <div id="primary-navigation" className={navGroupClassName}>
+          <nav className={styles.nav} aria-label="Primär">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={styles.navLink}
+                onClick={closeMenu}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+          <div className={styles.topbarActions}>
+            <Link
+              href="/blog"
+              className={`${styles.btn} ${styles.btnGhost}`}
+              onClick={closeMenu}
+            >
+              Blogg
             </Link>
-          ))}
-        </nav>
-        <div className={styles.topbarActions}>
-          <Link href="/blog" className={`${styles.btn} ${styles.btnGhost}`}>
-            Blogg
-          </Link>
-          <Link href="/login" className={`${styles.btn} ${styles.btnPrimary}`}>
-            Logga in
-          </Link>
+            <Link
+              href="/login"
+              className={`${styles.btn} ${styles.btnPrimary}`}
+              onClick={closeMenu}
+            >
+              Logga in
+            </Link>
+          </div>
         </div>
       </header>
 

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -26,6 +26,7 @@
   display: flex;
   gap: 20px;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .navLink {
@@ -34,6 +35,10 @@
   font-size: 15px;
   padding: 8px 10px;
   border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
@@ -48,6 +53,67 @@
   display: flex;
   gap: 12px;
   align-items: center;
+}
+
+.topbarNavGroup {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-left: auto;
+}
+
+.mobileMenuButton {
+  display: none;
+  align-items: center;
+  gap: 10px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #e2e8f0;
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.mobileMenuButton:hover,
+.mobileMenuButton:focus-visible {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: rgba(148, 163, 184, 0.55);
+  color: #ffffff;
+  outline: none;
+}
+
+.menuIcon {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.menuIcon span {
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.mobileMenuButton[data-open='true'] .menuIcon span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.mobileMenuButton[data-open='true'] .menuIcon span:nth-child(2) {
+  opacity: 0;
+}
+
+.mobileMenuButton[data-open='true'] .menuIcon span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.navGroupOpen {
+  display: flex;
 }
 
 .btn {
@@ -599,19 +665,60 @@
 
 @media (max-width: 900px) {
   .landingTopbar {
-    gap: 16px;
+    padding: 16px 20px;
     flex-wrap: wrap;
-    justify-content: center;
+    gap: 12px;
+  }
+
+  .mobileMenuButton {
+    display: inline-flex;
+  }
+
+  .topbarNavGroup {
+    order: 3;
+    width: 100%;
+    margin-left: 0;
+    display: none;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 18px;
+    padding: 18px 16px;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(8, 13, 23, 0.94);
+    box-shadow: 0 18px 40px rgba(2, 6, 23, 0.5);
+  }
+
+  .navGroupOpen {
+    display: flex;
   }
 
   .nav {
-    order: 3;
     width: 100%;
-    justify-content: center;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .navLink {
+    width: 100%;
+    background: rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.14);
+  }
+
+  .navLink:hover,
+  .navLink:focus-visible {
+    background: rgba(148, 163, 184, 0.25);
+    color: #ffffff;
   }
 
   .topbarActions {
-    order: 2;
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .topbarActions .btn {
+    width: 100%;
   }
 
   .statsGrid,
@@ -639,10 +746,6 @@
     height: 36px;
     font-size: 16px;
   }
-
-  .landingTopbar {
-    padding: 16px 20px;
-  }
 }
 
 @media (max-width: 520px) {
@@ -657,11 +760,6 @@
   .ctaActions {
     width: 100%;
     flex-direction: column;
-  }
-
-  .topbarActions {
-    width: 100%;
-    justify-content: center;
   }
 
   .btn {


### PR DESCRIPTION
## Summary
- add viewport metadata so mobile devices render the site at the correct scale
- convert the landing header to a client component with a toggleable mobile navigation
- refresh landing page styles so menus and buttons stack cleanly on small screens

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ceff327720832ba44a73119e5fe37d