### PR TITLE
Configure lint defaults and fix Next config export

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/next.config.js
+++ b/next.config.js
@@ -3,4 +3,4 @@ const nextConfig = {
   reactStrictMode: true,
 };
 
-export default nextConfig;
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- add the recommended Next.js ESLint configuration so linting no longer prompts for setup
- switch next.config.js back to a CommonJS export to eliminate module format warnings when running CLI tasks

## Testing
- npm run lint *(fails: ESLint package is not available from the npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d651ddd7b8832b81374663ffb9813d