### PR TITLE
Update BetSpread branding and responsive logo sizing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/login/page.module.css
+++ b/app/login/page.module.css
@@ -51,7 +51,7 @@
 
 .brandLogo {
   display: block;
-  width: 188px;
+  width: 220px;
   height: auto;
   filter: drop-shadow(0 0 24px rgba(56, 189, 248, 0.4));
 }
@@ -492,9 +492,15 @@
   }
 }
 
+@media (max-width: 900px) {
+  .brandLogo {
+    width: 188px;
+  }
+}
+
 @media (max-width: 720px) {
   .brandLogo {
-    width: 176px;
+    width: 170px;
   }
 
   .content {

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -59,7 +59,7 @@
 
 .brandLogo {
   display: block;
-  width: 188px;
+  width: 220px;
   height: auto;
   filter: drop-shadow(0 0 18px rgba(56, 189, 248, 0.35));
 }
@@ -664,6 +664,10 @@
 }
 
 @media (max-width: 900px) {
+  .brandLogo {
+    width: 188px;
+  }
+
   .landingTopbar {
     gap: 16px;
     flex-wrap: wrap;
@@ -686,11 +690,13 @@
   }
 }
 
-@media (max-width: 680px) {
+@media (max-width: 720px) {
   .brandLogo {
     width: 170px;
   }
+}
 
+@media (max-width: 680px) {
   .statsGrid,
   .featureGrid {
     grid-template-columns: 1fr;

--- a/components/Logo.jsx
+++ b/components/Logo.jsx
@@ -7,9 +7,10 @@ export default function Logo({ className, priority = false }) {
     <Image
       src="/betspread-logo.svg"
       alt="BetSpread"
-      width={240}
-      height={64}
+      width={1024}
+      height={576}
       className={className}
+      sizes="(max-width: 520px) 150px, (max-width: 720px) 170px, (max-width: 900px) 188px, 220px"
       priority={priority}
     />
   );

--- a/components/auth-layout.module.css
+++ b/components/auth-layout.module.css
@@ -60,7 +60,7 @@
 
 .brandLogo {
   display: block;
-  width: 188px;
+  width: 220px;
   height: auto;
   filter: drop-shadow(0 0 24px rgba(56, 189, 248, 0.45));
 }
@@ -166,9 +166,21 @@
   gap: 18px;
 }
 
+@media (max-width: 900px) {
+  .brandLogo {
+    width: 188px;
+  }
+}
+
+@media (max-width: 720px) {
+  .brandLogo {
+    width: 170px;
+  }
+}
+
 @media (max-width: 520px) {
   .brandLogo {
-    width: 160px;
+    width: 150px;
   }
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -3,4 +3,4 @@ const nextConfig = {
   reactStrictMode: true,
 };
 
-export default nextConfig;
+module.exports = nextConfig;

--- a/public/betspread-logo.svg
+++ b/public/betspread-logo.svg
@@ -1,39 +1,47 @@
-<svg width="280" height="64" viewBox="0 0 280 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="1024" height="576" viewBox="0 0 1024 576" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">BetSpread logotyp</title>
+  <desc id="logoDesc">Mörk gradient med ett turkosfärgat diagram och texten BetSpread</desc>
   <defs>
-    <linearGradient id="betspreadGradient" x1="0" y1="0" x2="280" y2="64" gradientUnits="userSpaceOnUse">
-<svg width="240" height="64" viewBox="0 0 240 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <linearGradient id="betspreadGradient" x1="0" y1="0" x2="240" y2="64" gradientUnits="userSpaceOnUse">
+    <linearGradient id="bgGradient" x1="128" y1="32" x2="896" y2="544" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B2535" />
+      <stop offset="1" stop-color="#052033" />
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="160" y1="128" x2="820" y2="448" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#2DD4BF" />
       <stop offset="1" stop-color="#38BDF8" />
     </linearGradient>
+    <filter id="glow" x="56" y="80" width="520" height="420" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
   </defs>
-  <g>
-    <rect x="12" y="30" width="10" height="22" rx="3" fill="url(#betspreadGradient)" />
-    <rect x="28" y="24" width="10" height="28" rx="3" fill="url(#betspreadGradient)" />
-    <rect x="44" y="18" width="10" height="34" rx="3" fill="url(#betspreadGradient)" />
-    <rect x="60" y="12" width="10" height="40" rx="3" fill="url(#betspreadGradient)" />
+  <rect width="1024" height="576" rx="40" fill="url(#bgGradient)" />
+  <g filter="url(#glow)">
+    <rect x="96" y="284" width="64" height="180" rx="16" fill="url(#accentGradient)" />
+    <rect x="192" y="240" width="64" height="224" rx="16" fill="url(#accentGradient)" />
+    <rect x="288" y="192" width="64" height="272" rx="16" fill="url(#accentGradient)" />
+    <rect x="384" y="144" width="64" height="320" rx="16" fill="url(#accentGradient)" />
     <path
-      d="M14 26L32 16L48 22L72 6"
-      d="M14 32L32 20L48 30L72 10"
-      fill="none"
-      stroke="url(#betspreadGradient)"
-      stroke-width="4"
+      d="M128 276L224 232L320 200L488 124"
+      stroke="url(#accentGradient)"
+      stroke-width="18"
       stroke-linecap="round"
       stroke-linejoin="round"
+      fill="none"
     />
-    <path d="M70 2L82 4L74 16" fill="url(#betspreadGradient)" />
-    <path d="M70 6L82 8L74 18" fill="url(#betspreadGradient)" />
+    <path d="M464 94L536 114L484 180" fill="url(#accentGradient)" />
   </g>
   <text
-    x="98"
-    y="42"
-    fill="url(#betspreadGradient)"
-    font-family="'Poppins', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
-    font-size="28"
+    x="440"
+    y="328"
+    fill="url(#accentGradient)"
+    font-family="'Poppins','Inter','Segoe UI','Helvetica Neue',Arial,sans-serif"
+    font-size="96"
     font-weight="700"
-    letter-spacing="0.14em"
-    text-rendering="geometricPrecision"
+    letter-spacing="0.05em"
   >
     BETSPREAD
   </text>


### PR DESCRIPTION
## Summary
- replace the BetSpread logo asset with the full branded graphic, including gradient background and accessibility metadata
- update the shared Logo component dimensions and responsive breakpoints so the complete logo renders correctly across the marketing and auth layouts

## Testing
- npm run lint *(fails: ESLint package is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d651ddd7b8832b81374663ffb9813d