### PR TITLE
Add +EV calculator tool

### DIFF
--- a/app/(app)/verktyg/ev/README.md
+++ b/app/(app)/verktyg/ev/README.md
@@ -1,0 +1,21 @@
+# +EV-beräknare
+
+Detta verktyg räknar ut implied probability, edge, ROI, Kelly-fraktion och förväntat värde för ett spel eller en kombination (parlay). Alla beräkningar sker i realtid när användaren ändrar formuläret.
+
+## Formler
+- **Implied probability**: \( p_\text{implied} = 1 / \text{decimalodds} \)
+- **Break-even probability**: \( p_\text{break-even} = 1 / \text{decimalodds} \)
+- **Förväntat värde (EV)**: \( EV = p_\text{egen} \cdot (\text{odds} - 1) \cdot \text{insats} - (1 - p_\text{egen}) \cdot \text{insats} \)
+- **ROI**: \( ROI = (\text{odds} \cdot p_\text{egen} - 1) \cdot 100 \)
+- **Edge**: \( Edge = (p_\text{egen} - p_\text{implied}) \cdot 100 \)
+- **Kelly-fraktion**: \( f^* = ((\text{odds} - 1) \cdot p_\text{egen} - (1 - p_\text{egen})) / (\text{odds} - 1) \)
+
+## Exempel
+Ett spel med decimalodds 2.00, egen sannolikhet 55 % och insats 100 kr ger:
+- Implied probability: 50 %
+- EV: 10 kr
+- ROI: 10 %
+- Kelly-fraktion: 10 % (full Kelly)
+
+## Tester
+Enhetstester finns i `tests/ev/ev.spec.ts` och täcker konverteringar mellan oddsformat, EV/ROI-beräkningar samt Kelly för både singelspel och parlay.

--- a/app/(app)/verktyg/ev/_components/EvForm.tsx
+++ b/app/(app)/verktyg/ev/_components/EvForm.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import * as React from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useFieldArray, useForm } from 'react-hook-form';
+
+import { Alert } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+
+import { calculateEv } from '../_lib/ev';
+import { EvComputation, EvFormValues, evFormSchema } from '../_lib/types';
+
+const defaultValues: EvFormValues = {
+  oddsFormat: 'decimal',
+  oddsValue: '2.00',
+  ownProbability: '55',
+  stake: '100',
+  bankroll: '',
+  edgeMode: 'auto',
+  manualEdge: '',
+  rounding: 'two',
+  parlayEnabled: false,
+  parlayLegs: [
+    { id: 'ben-1', oddsFormat: 'decimal', oddsValue: '2.00', ownProbability: '55' },
+    { id: 'ben-2', oddsFormat: 'decimal', oddsValue: '1.80', ownProbability: '60' },
+  ],
+};
+
+interface EvFormProps {
+  onChange: (result: EvComputation | null) => void;
+}
+
+export function EvForm({ onChange }: EvFormProps) {
+  const form = useForm<EvFormValues>({
+    resolver: zodResolver(evFormSchema),
+    defaultValues,
+    mode: 'onChange',
+  });
+
+  const { control, register, watch, reset, handleSubmit, formState } = form;
+
+  const parlayFieldArray = useFieldArray({
+    control,
+    name: 'parlayLegs',
+  });
+
+  React.useEffect(() => {
+    onChange(calculateEv(defaultValues));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    const subscription = watch((values, { type }) => {
+      if (type === 'change' || type === 'blur') {
+        const parsed = evFormSchema.safeParse(values as EvFormValues);
+        if (parsed.success) {
+          try {
+            const computation = calculateEv(parsed.data);
+            onChange(computation);
+          } catch (error) {
+            console.error(error);
+            onChange(null);
+          }
+        } else {
+          onChange(null);
+        }
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [onChange, watch]);
+
+  const onSubmit = React.useCallback(
+    (values: EvFormValues) => {
+      const parsed = evFormSchema.safeParse(values);
+      if (!parsed.success) {
+        onChange(null);
+        return;
+      }
+      const computation = calculateEv(parsed.data);
+      onChange(computation);
+    },
+    [onChange]
+  );
+
+  const handleReset = React.useCallback(() => {
+    reset(defaultValues);
+    onChange(calculateEv(defaultValues));
+  }, [onChange, reset]);
+
+  const showManualEdge = watch('edgeMode') === 'manual';
+  const parlayEnabled = watch('parlayEnabled');
+
+  const addParlayLeg = React.useCallback(() => {
+    parlayFieldArray.append({
+      id: `ben-${parlayFieldArray.fields.length + 1}`,
+      oddsFormat: 'decimal',
+      oddsValue: '2.00',
+      ownProbability: '',
+    });
+  }, [parlayFieldArray]);
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="space-y-6 rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-card"
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <FormField label="Oddsformat" htmlFor="oddsFormat" error={formState.errors.oddsValue?.message}>
+          <Select id="oddsFormat" {...register('oddsFormat')}>
+            <option value="decimal">Decimal (EU)</option>
+            <option value="american">Amerikanska (+/-)</option>
+            <option value="fraction">Fraktion (t.ex. 5/2)</option>
+          </Select>
+        </FormField>
+        <FormField label="Odds" htmlFor="oddsValue" error={formState.errors.oddsValue?.message}>
+          <Input id="oddsValue" inputMode="decimal" {...register('oddsValue')} />
+        </FormField>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <FormField
+          label="Egen sannolikhet %"
+          htmlFor="ownProbability"
+          description="Valfritt – lämna tomt för implied probability"
+          error={formState.errors.ownProbability?.message}
+        >
+          <Input id="ownProbability" inputMode="decimal" {...register('ownProbability')} />
+        </FormField>
+        <FormField label="Insats" htmlFor="stake" error={formState.errors.stake?.message}>
+          <Input id="stake" inputMode="decimal" {...register('stake')} />
+        </FormField>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <FormField label="Bankrulle" htmlFor="bankroll" error={formState.errors.bankroll?.message}>
+          <Input id="bankroll" inputMode="decimal" placeholder="Valfritt" {...register('bankroll')} />
+        </FormField>
+        <FormField label="Avrundning" htmlFor="rounding">
+          <Select id="rounding" {...register('rounding')}>
+            <option value="none">Ingen</option>
+            <option value="two">2 decimaler</option>
+            <option value="krona">Närmaste krona</option>
+          </Select>
+        </FormField>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <FormField label="Edge-läge" htmlFor="edgeMode">
+          <Select id="edgeMode" {...register('edgeMode')}>
+            <option value="auto">Auto (egen sannolikhet vs implied)</option>
+            <option value="manual">Manuell edge %</option>
+          </Select>
+        </FormField>
+        {showManualEdge ? (
+          <FormField
+            label="Min edge %"
+            htmlFor="manualEdge"
+            error={formState.errors.manualEdge?.message}
+          >
+            <Input id="manualEdge" inputMode="decimal" {...register('manualEdge')} />
+          </FormField>
+        ) : null}
+      </div>
+
+      <div className="space-y-3 rounded-lg border border-slate-800/70 bg-slate-950/40 p-4">
+        <label className="flex items-center gap-3 text-sm font-medium text-slate-200">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-slate-700 bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+            {...register('parlayEnabled')}
+          />
+          Aktivera parlay (flera ben)
+        </label>
+        {parlayEnabled ? (
+          <div className="space-y-4">
+            {parlayFieldArray.fields.map((field, index) => (
+              <div
+                key={field.id}
+                className="space-y-3 rounded-md border border-slate-800/70 bg-slate-900/60 p-4"
+              >
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-slate-200">Ben {index + 1}</p>
+                  {parlayFieldArray.fields.length > 1 ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="text-xs text-slate-300 hover:text-red-200"
+                      onClick={() => parlayFieldArray.remove(index)}
+                    >
+                      Ta bort
+                    </Button>
+                  ) : null}
+                </div>
+                <div className="grid gap-3 md:grid-cols-3">
+                  <FormField
+                    label="Format"
+                    htmlFor={`parlay-leg-${field.id}-format`}
+                    error={formState.errors.parlayLegs?.[index]?.oddsValue?.message}
+                  >
+                    <Select
+                      id={`parlay-leg-${field.id}-format`}
+                      {...register(`parlayLegs.${index}.oddsFormat` as const)}
+                    >
+                      <option value="decimal">Decimal</option>
+                      <option value="american">Amerikanska</option>
+                      <option value="fraction">Fraktion</option>
+                    </Select>
+                  </FormField>
+                  <FormField
+                    label="Odds"
+                    htmlFor={`parlay-leg-${field.id}-odds`}
+                    error={formState.errors.parlayLegs?.[index]?.oddsValue?.message}
+                  >
+                    <Input
+                      id={`parlay-leg-${field.id}-odds`}
+                      inputMode="decimal"
+                      {...register(`parlayLegs.${index}.oddsValue` as const)}
+                    />
+                  </FormField>
+                  <FormField
+                    label="Egen sannolikhet %"
+                    htmlFor={`parlay-leg-${field.id}-prob`}
+                    error={formState.errors.parlayLegs?.[index]?.ownProbability?.message}
+                  >
+                    <Input
+                      id={`parlay-leg-${field.id}-prob`}
+                      inputMode="decimal"
+                      placeholder="Tom = implied"
+                      {...register(`parlayLegs.${index}.ownProbability` as const)}
+                    />
+                  </FormField>
+                </div>
+              </div>
+            ))}
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="secondary" onClick={addParlayLeg}>
+                Lägg till ben
+              </Button>
+              {parlayFieldArray.fields.length > 0 ? (
+                <Alert variant="info" className="text-xs">
+                  Tips: egen sannolikhet lämnas tom för att använda implied probability per ben.
+                </Alert>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {formState.errors.root ? (
+        <Alert variant="destructive">{formState.errors.root.message}</Alert>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button type="submit">Beräkna</Button>
+        <Button type="button" variant="outline" onClick={handleReset}>
+          Rensa
+        </Button>
+        <p className="text-xs text-slate-400">
+          Formuläret uppdaterar resultaten automatiskt när du ändrar något.
+        </p>
+      </div>
+    </form>
+  );
+}
+
+interface FormFieldProps {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+  error?: string;
+  description?: string;
+}
+
+function FormField({ label, htmlFor, children, error, description }: FormFieldProps) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {description ? <p className="text-xs text-slate-400">{description}</p> : null}
+      {children}
+      {error ? <p className="text-xs text-red-300">{error}</p> : null}
+    </div>
+  );
+}

--- a/app/(app)/verktyg/ev/_components/EvResults.tsx
+++ b/app/(app)/verktyg/ev/_components/EvResults.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import * as React from 'react';
+
+import { Alert } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useToast } from '@/components/ui/toast';
+
+import { EvComputation, NormalizedLeg } from '../_lib/types';
+
+const currencyFormatter = new Intl.NumberFormat('sv-SE', {
+  style: 'currency',
+  currency: 'SEK',
+  maximumFractionDigits: 2,
+});
+
+const percentFormatter = new Intl.NumberFormat('sv-SE', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+interface EvResultsProps {
+  computation: EvComputation | null;
+}
+
+export function EvResults({ computation }: EvResultsProps) {
+  const { toast } = useToast();
+
+  const handleCopy = React.useCallback(async () => {
+    if (!computation) {
+      return;
+    }
+    const single = computation.single;
+    const summaryLines = [
+      `Singelspel: EV ${formatCurrency(single.evValue)}, ROI ${formatPercent(single.roiPercent)}, Edge ${formatPercent(single.edgePercent)}, Kelly ${(single.kellyFraction * 100).toFixed(2)} %`,
+    ];
+    if (computation.parlay) {
+      const parlay = computation.parlay;
+      summaryLines.push(
+        `Parlay: EV ${formatCurrency(parlay.evValue)}, ROI ${formatPercent(parlay.roiPercent)}, Edge ${formatPercent(parlay.edgePercent)}, Kelly ${(parlay.kellyFraction * 100).toFixed(2)} %`
+      );
+    }
+    try {
+      await navigator.clipboard.writeText(summaryLines.join('\n'));
+      toast({
+        title: 'Resultat kopierat',
+        description: 'Snabbsummeringen finns nu i urklippet.',
+        variant: 'success',
+      });
+    } catch (error) {
+      toast({
+        title: 'Kunde inte kopiera',
+        description: 'Kontrollera behörigheter för urklipp i din webbläsare.',
+        variant: 'destructive',
+      });
+    }
+  }, [computation, toast]);
+
+  if (!computation) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Snabbsummering</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-slate-300">
+            Fyll i formuläret för att se beräkningarna i realtid.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { single, parlay } = computation;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-col space-y-3 md:flex-row md:items-center md:justify-between">
+          <CardTitle>Snabbsummering</CardTitle>
+          <Button type="button" variant="secondary" onClick={handleCopy}>
+            Kopiera resultat
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-4">
+            <SummaryMetric label="EV" tooltip="Förväntat värde per spel" value={formatCurrency(single.evValue)} trend={single.evValue} />
+            <SummaryMetric
+              label="ROI"
+              tooltip="Avkastning per spel baserat på egen sannolikhet"
+              value={formatPercent(single.roiPercent)}
+              trend={single.roiPercent}
+            />
+            <SummaryMetric
+              label="Edge"
+              tooltip="Skillnad mellan egen och implied sannolikhet"
+              value={formatPercent(single.edgePercent)}
+              trend={single.edgePercent}
+            />
+            <SummaryMetric
+              label="Kelly f*"
+              tooltip="Optimal fraktion av bankrulle enligt Kelly"
+              value={`${percentFormatter.format(single.kellyFraction * 100)} %`}
+              trend={single.kellyFraction * 100}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <ResultCard title="Singelspel" description="Detaljerad vy för ditt enskilda spel">
+        <div className="grid gap-6 md:grid-cols-2">
+          <div className="space-y-4">
+            <SectionHeading title="Sannolikheter och odds" />
+            <KeyValue label="Implied probability" tooltip="Oddsens inbyggda sannolikhet" value={formatProbability(single.impliedProbability)} />
+            <KeyValue label="Egen sannolikhet" tooltip="Din uppskattade träffprocent" value={formatProbability(single.ownProbability)} />
+            <KeyValue label="Break-even" tooltip="Krävd träffprocent för +-0" value={formatProbability(single.breakEvenProbability)} />
+            <KeyValue label="Decimalodds" value={single.decimalOdds.toFixed(2)} />
+            <KeyValue label="Amerikanska odds" value={single.americanOdds} />
+            <KeyValue label="Fraktion" value={single.fractionalOdds} />
+          </div>
+          <div className="space-y-4">
+            <SectionHeading title="Resultat" />
+            <KeyValue label="Insats" value={formatCurrency(single.stake)} />
+            <KeyValue label="Netto vid vinst" tooltip="Utbetalning minus insats" value={formatCurrency(single.netProfit)} />
+            <KeyValue label="Förväntat värde" tooltip="p*vinsten - (1-p)*insats" value={formatCurrency(single.evValue)} />
+            <KeyValue label="ROI" value={formatPercent(single.roiPercent)} />
+            <KeyValue label="Edge" value={formatPercent(single.edgePercent)} />
+            <KeyValue label="Kelly f*" value={`${percentFormatter.format(single.kellyFraction * 100)} %`} />
+            {single.bankroll ? (
+              <div className="space-y-2">
+                <p className="text-sm font-semibold text-slate-200">Rekommenderad insats</p>
+                {single.kellyFraction <= 0 ? (
+                  <Alert variant="info" className="text-xs">
+                    Ingen insats rekommenderas (negativ Kelly).
+                  </Alert>
+                ) : (
+                  <ul className="list-disc space-y-1 pl-5 text-sm text-slate-200">
+                    <li>Full Kelly: {formatCurrency(single.kellyRecommendations?.full ?? 0)}</li>
+                    <li>½ Kelly: {formatCurrency(single.kellyRecommendations?.half ?? 0)}</li>
+                    <li>¼ Kelly: {formatCurrency(single.kellyRecommendations?.quarter ?? 0)}</li>
+                  </ul>
+                )}
+              </div>
+            ) : (
+              <Alert variant="info" className="text-xs">
+                Kelly-faktorn är {percentFormatter.format(single.kellyFraction * 100)} %. Ange bankrulle för belopp.
+              </Alert>
+            )}
+            {single.warnings.length > 0 ? (
+              <div className="space-y-2">
+                {single.warnings.map((warning) => (
+                  <Alert key={warning} variant="destructive" className="text-xs">
+                    {warning}
+                  </Alert>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </ResultCard>
+
+      {parlay ? (
+        <ResultCard title="Parlay" description="Sammanställning för kombinationsspel">
+          <div className="space-y-6">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-3">
+                <SectionHeading title="Leggar" />
+                <div className="space-y-2">
+                  {parlay.legs.map((leg, index) => (
+                    <LegSummary key={leg.id} leg={leg} index={index} />
+                  ))}
+                </div>
+              </div>
+              <div className="space-y-4">
+                <SectionHeading title="Resultat" />
+                <KeyValue label="Kombinerade odds" value={parlay.decimalOdds.toFixed(2)} />
+                <KeyValue label="Amerikanska" value={parlay.americanOdds} />
+                <KeyValue label="Fraktion" value={parlay.fractionalOdds} />
+                <KeyValue label="Kombinerad sannolikhet" value={formatProbability(parlay.ownProbability)} />
+                <KeyValue label="Implied" value={formatProbability(parlay.impliedProbability)} />
+                <KeyValue label="Break-even" value={formatProbability(parlay.breakEvenProbability)} />
+                <KeyValue label="EV" value={formatCurrency(parlay.evValue)} />
+                <KeyValue label="ROI" value={formatPercent(parlay.roiPercent)} />
+                <KeyValue label="Edge" value={formatPercent(parlay.edgePercent)} />
+                <KeyValue label="Kelly f*" value={`${percentFormatter.format(parlay.kellyFraction * 100)} %`} />
+              </div>
+            </div>
+            {parlay.kellyFraction <= 0 ? (
+              <Alert variant="info" className="text-xs">
+                Ingen insats rekommenderas (negativ Kelly).
+              </Alert>
+            ) : parlay.kellyRecommendations ? (
+              <Alert variant="default" className="text-xs text-emerald-100">
+                Rek. insats: Full Kelly {formatCurrency(parlay.kellyRecommendations.full)}, halv {formatCurrency(parlay.kellyRecommendations.half)}, kvart {formatCurrency(parlay.kellyRecommendations.quarter)}.
+              </Alert>
+            ) : null}
+            {parlay.warnings.length > 0 ? (
+              <div className="space-y-2">
+                {parlay.warnings.map((warning) => (
+                  <Alert key={warning} variant="destructive" className="text-xs">
+                    {warning}
+                  </Alert>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </ResultCard>
+      ) : null}
+    </div>
+  );
+}
+
+function SummaryMetric({
+  label,
+  value,
+  tooltip,
+  trend,
+}: {
+  label: string;
+  value: string;
+  tooltip?: string;
+  trend?: number;
+}) {
+  const color = trendColor(trend ?? 0);
+  return (
+    <div className="rounded-lg border border-slate-800/80 bg-slate-900/70 p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+        {label}
+        {tooltip ? <InfoTooltip text={tooltip} /> : null}
+      </p>
+      <p className={`mt-2 text-xl font-semibold ${color}`}>{value}</p>
+    </div>
+  );
+}
+
+function ResultCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {description ? <p className="text-sm text-slate-400">{description}</p> : null}
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+function SectionHeading({ title }: { title: string }) {
+  return <p className="text-sm font-semibold uppercase tracking-wide text-slate-300">{title}</p>;
+}
+
+function KeyValue({
+  label,
+  value,
+  tooltip,
+}: {
+  label: string;
+  value: string;
+  tooltip?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1 text-sm text-slate-200">
+      <span className="font-medium text-slate-300">
+        {label}
+        {tooltip ? <InfoTooltip text={tooltip} /> : null}
+      </span>
+      <span className="font-semibold text-slate-100">{value}</span>
+    </div>
+  );
+}
+
+function LegSummary({ leg, index }: { leg: NormalizedLeg; index: number }) {
+  return (
+    <div className="rounded-lg border border-slate-800/70 bg-slate-900/60 p-3 text-sm text-slate-200">
+      <p className="font-semibold text-slate-100">Ben {index + 1}</p>
+      <p>Odds: {leg.decimalOdds.toFixed(2)} ({leg.americanOdds})</p>
+      <p>Fraktion: {leg.fractionalOdds}</p>
+      <p>Egen sannolikhet: {formatProbability(leg.ownProbability)}</p>
+      <p>Implied: {formatProbability(leg.impliedProbability)}</p>
+    </div>
+  );
+}
+
+function InfoTooltip({ text }: { text: string }) {
+  return (
+    <span
+      className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-slate-800 text-[11px] text-slate-300"
+      title={text}
+      aria-label={text}
+    >
+      ⓘ
+    </span>
+  );
+}
+
+function trendColor(value: number): string {
+  if (value > 0) {
+    return 'text-emerald-300';
+  }
+  if (value < 0) {
+    return 'text-rose-300';
+  }
+  return 'text-slate-200';
+}
+
+function formatCurrency(value: number): string {
+  return currencyFormatter.format(value);
+}
+
+function formatPercent(value: number): string {
+  return `${percentFormatter.format(value)} %`;
+}
+
+function formatProbability(probability: number): string {
+  return `${percentFormatter.format(probability * 100)} %`;
+}

--- a/app/(app)/verktyg/ev/_lib/ev.ts
+++ b/app/(app)/verktyg/ev/_lib/ev.ts
@@ -1,0 +1,303 @@
+import { toAmerican, toDecimal, toFraction, impliedFromDecimal } from './odds';
+import {
+  EvComputation,
+  EvFormValues,
+  NormalizedInputs,
+  NormalizedLeg,
+  ParlayResult,
+  ProbabilitySource,
+  RoundingMode,
+  SingleResult,
+  parseOptionalNumber,
+  parseOptionalProbability,
+} from './types';
+
+export function netProfit(decimalOdds: number, stake: number): number {
+  return (decimalOdds - 1) * stake;
+}
+
+export function evCurrency(
+  decimalOdds: number,
+  ownProbability: number,
+  stake: number
+): number {
+  return ownProbability * netProfit(decimalOdds, stake) - (1 - ownProbability) * stake;
+}
+
+export function roiPercent(decimalOdds: number, ownProbability: number): number {
+  return (decimalOdds * ownProbability - 1) * 100;
+}
+
+export function breakEvenProbability(decimalOdds: number): number {
+  return 1 / decimalOdds;
+}
+
+export function edgePercent(ownProbability: number, impliedProbability: number): number {
+  return (ownProbability - impliedProbability) * 100;
+}
+
+export function kellyFraction(decimalOdds: number, ownProbability: number): number {
+  const b = decimalOdds - 1;
+  if (b <= 0) {
+    return 0;
+  }
+  const q = 1 - ownProbability;
+  return (b * ownProbability - q) / b;
+}
+
+export function roundValue(value: number, mode: RoundingMode): number {
+  switch (mode) {
+    case 'two':
+      return Math.round(value * 100) / 100;
+    case 'krona':
+      return Math.round(value);
+    case 'none':
+    default:
+      return value;
+  }
+}
+
+function clampProbability(probability: number): number {
+  if (Number.isNaN(probability)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, probability));
+}
+
+function clampKelly(fraction: number): number {
+  if (Number.isNaN(fraction)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, fraction));
+}
+
+function parseStake(value: string): number {
+  const parsed = parseOptionalNumber(value);
+  if (parsed === null || parsed <= 0) {
+    throw new Error('Insatsen måste vara positiv');
+  }
+  return parsed;
+}
+
+function parseBankroll(value?: string): number | undefined {
+  const parsed = parseOptionalNumber(value);
+  if (parsed === null) {
+    return undefined;
+  }
+  if (parsed <= 0) {
+    throw new Error('Bankrullen måste vara positiv');
+  }
+  return parsed;
+}
+
+function parseManualEdge(values: EvFormValues): number | undefined {
+  if (values.edgeMode !== 'manual') {
+    return undefined;
+  }
+  const parsed = parseOptionalNumber(values.manualEdge);
+  if (parsed === null) {
+    throw new Error('Ogiltig edge');
+  }
+  return parsed;
+}
+
+function determineProbability(
+  implied: number,
+  values: EvFormValues,
+  manualEdge?: number
+): { probability: number; source: ProbabilitySource } {
+  if (values.edgeMode === 'manual' && manualEdge !== undefined) {
+    return {
+      probability: clampProbability(implied + manualEdge / 100),
+      source: 'manualEdge',
+    };
+  }
+
+  const ownProbability = parseOptionalProbability(values.ownProbability);
+  if (ownProbability !== null) {
+    return { probability: clampProbability(ownProbability), source: 'user' };
+  }
+
+  return { probability: clampProbability(implied), source: 'implied' };
+}
+
+function normalizeLeg(leg: EvFormValues['parlayLegs'][number], index: number): NormalizedLeg {
+  const decimalOdds = toDecimal(leg.oddsFormat, leg.oddsValue);
+  const impliedProbability = impliedFromDecimal(decimalOdds);
+  const ownProbabilityCandidate = parseOptionalProbability(leg.ownProbability);
+  const probability =
+    ownProbabilityCandidate !== null ? ownProbabilityCandidate : impliedProbability;
+  const source: ProbabilitySource =
+    ownProbabilityCandidate !== null ? 'user' : 'implied';
+
+  return {
+    id: leg.id || `ben-${index + 1}`,
+    format: leg.oddsFormat,
+    oddsInput: leg.oddsValue,
+    decimalOdds,
+    impliedProbability,
+    ownProbability: clampProbability(probability),
+    ownProbabilitySource: source,
+    americanOdds: toAmerican(decimalOdds),
+    fractionalOdds: toFraction(decimalOdds),
+  };
+}
+
+export function normalizeInputs(values: EvFormValues): NormalizedInputs {
+  const decimalOdds = toDecimal(values.oddsFormat, values.oddsValue);
+  const impliedProbability = impliedFromDecimal(decimalOdds);
+  const stake = parseStake(values.stake);
+  const bankroll = parseBankroll(values.bankroll);
+  const manualEdge = parseManualEdge(values);
+  const { probability, source } = determineProbability(
+    impliedProbability,
+    values,
+    manualEdge
+  );
+
+  const parlayLegs = values.parlayLegs.map((leg, index) => normalizeLeg(leg, index));
+
+  return {
+    stake,
+    bankroll,
+    rounding: values.rounding,
+    edgeMode: values.edgeMode,
+    manualEdgePercent: manualEdge,
+    baseFormat: values.oddsFormat,
+    decimalOdds,
+    impliedProbability,
+    ownProbability: probability,
+    ownProbabilitySource: source,
+    americanOdds: toAmerican(decimalOdds),
+    fractionalOdds: toFraction(decimalOdds),
+    parlayLegs,
+    parlayEnabled: values.parlayEnabled,
+  };
+}
+
+export function calculateEv(values: EvFormValues): EvComputation {
+  const inputs = normalizeInputs(values);
+  const single = buildSingleResult(inputs);
+  const parlay = buildParlayResult(inputs);
+
+  return { inputs, single, parlay };
+}
+
+function buildSingleResult(inputs: NormalizedInputs): SingleResult {
+  const breakEven = breakEvenProbability(inputs.decimalOdds);
+  const evValue = evCurrency(inputs.decimalOdds, inputs.ownProbability, inputs.stake);
+  const roi = roiPercent(inputs.decimalOdds, inputs.ownProbability);
+  const edge =
+    inputs.edgeMode === 'manual' && typeof inputs.manualEdgePercent === 'number'
+      ? inputs.manualEdgePercent
+      : edgePercent(inputs.ownProbability, inputs.impliedProbability);
+  const kellyRaw = kellyFraction(inputs.decimalOdds, inputs.ownProbability);
+  const kelly = clampKelly(kellyRaw);
+  const warnings: string[] = [];
+  if (kellyRaw <= 0) {
+    warnings.push('Kelly-fractionen är negativ, ingen insats rekommenderas.');
+  }
+  if (kellyRaw > 1) {
+    warnings.push('Kelly-fractionen överstiger 100 %, begränsa insatsen.');
+  }
+
+  const recommendations =
+    typeof inputs.bankroll === 'number'
+      ? {
+          full: roundValue(inputs.bankroll * kelly, inputs.rounding),
+          half: roundValue(inputs.bankroll * kelly * 0.5, inputs.rounding),
+          quarter: roundValue(inputs.bankroll * kelly * 0.25, inputs.rounding),
+        }
+      : undefined;
+
+  return {
+    decimalOdds: inputs.decimalOdds,
+    americanOdds: inputs.americanOdds,
+    fractionalOdds: inputs.fractionalOdds,
+    impliedProbability: inputs.impliedProbability,
+    ownProbability: inputs.ownProbability,
+    ownProbabilitySource: inputs.ownProbabilitySource,
+    breakEvenProbability: breakEven,
+    stake: inputs.stake,
+    netProfit: netProfit(inputs.decimalOdds, inputs.stake),
+    evValue: roundValue(evValue, inputs.rounding),
+    roiPercent: roi,
+    edgePercent: edge,
+    kellyFraction: kelly,
+    kellyRecommendations: recommendations,
+    bankroll: inputs.bankroll,
+    rounding: inputs.rounding,
+    manualEdgePercent: inputs.manualEdgePercent,
+    warnings,
+  };
+}
+
+function buildParlayResult(inputs: NormalizedInputs): ParlayResult | undefined {
+  if (!inputs.parlayEnabled || inputs.parlayLegs.length === 0) {
+    return undefined;
+  }
+
+  const decimalOdds = inputs.parlayLegs.reduce(
+    (total, leg) => total * leg.decimalOdds,
+    1
+  );
+  const impliedProbability = inputs.parlayLegs.reduce(
+    (total, leg) => total * leg.impliedProbability,
+    1
+  );
+  const ownProbability = inputs.parlayLegs.reduce(
+    (total, leg) => total * leg.ownProbability,
+    1
+  );
+  const probabilitySource: ProbabilitySource = inputs.parlayLegs.every(
+    (leg) => leg.ownProbabilitySource === 'implied'
+  )
+    ? 'implied'
+    : 'user';
+
+  const breakEven = breakEvenProbability(decimalOdds);
+  const evValue = evCurrency(decimalOdds, ownProbability, inputs.stake);
+  const roi = roiPercent(decimalOdds, ownProbability);
+  const edge = edgePercent(ownProbability, impliedProbability);
+  const kellyRaw = kellyFraction(decimalOdds, ownProbability);
+  const kelly = clampKelly(kellyRaw);
+  const warnings: string[] = [];
+  if (kellyRaw <= 0) {
+    warnings.push('Kelly-fractionen är negativ, ingen insats rekommenderas.');
+  }
+  if (kellyRaw > 1) {
+    warnings.push('Kelly-fractionen överstiger 100 %, begränsa insatsen.');
+  }
+
+  const recommendations =
+    typeof inputs.bankroll === 'number'
+      ? {
+          full: roundValue(inputs.bankroll * kelly, inputs.rounding),
+          half: roundValue(inputs.bankroll * kelly * 0.5, inputs.rounding),
+          quarter: roundValue(inputs.bankroll * kelly * 0.25, inputs.rounding),
+        }
+      : undefined;
+
+  return {
+    decimalOdds,
+    americanOdds: toAmerican(decimalOdds),
+    fractionalOdds: toFraction(decimalOdds),
+    impliedProbability,
+    ownProbability,
+    ownProbabilitySource: probabilitySource,
+    breakEvenProbability: breakEven,
+    stake: inputs.stake,
+    netProfit: netProfit(decimalOdds, inputs.stake),
+    evValue: roundValue(evValue, inputs.rounding),
+    roiPercent: roi,
+    edgePercent: edge,
+    kellyFraction: kelly,
+    kellyRecommendations: recommendations,
+    bankroll: inputs.bankroll,
+    rounding: inputs.rounding,
+    warnings,
+    legs: inputs.parlayLegs,
+  };
+}
+
+export type { NormalizedInputs, NormalizedLeg };

--- a/app/(app)/verktyg/ev/_lib/odds.ts
+++ b/app/(app)/verktyg/ev/_lib/odds.ts
@@ -1,0 +1,108 @@
+import { OddsFormat } from './types';
+
+export function parseLocaleNumber(input: string): number {
+  const normalized = input.replace(',', '.');
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) {
+    throw new Error('Ogiltigt tal');
+  }
+  return parsed;
+}
+
+export function parseDecimalOdds(value: string): number {
+  const parsed = parseLocaleNumber(value.trim());
+  if (parsed <= 1) {
+    throw new Error('Decimalodds måste vara större än 1');
+  }
+  return parsed;
+}
+
+export function parseAmericanOdds(value: string): number {
+  const parsed = parseLocaleNumber(value.trim());
+  if (parsed === 0) {
+    throw new Error('Amerikanska odds får inte vara 0');
+  }
+  if (parsed > 0) {
+    return 1 + parsed / 100;
+  }
+  return 1 + 100 / Math.abs(parsed);
+}
+
+export function parseFractionOdds(value: string): { numerator: number; denominator: number } {
+  const parts = value.split('/');
+  if (parts.length !== 2) {
+    throw new Error('Fraktionella odds måste anges som n/d');
+  }
+  const numerator = parseLocaleNumber(parts[0].trim());
+  const denominator = parseLocaleNumber(parts[1].trim());
+  if (denominator === 0) {
+    throw new Error('Nämnaren får inte vara 0');
+  }
+  if (numerator <= 0 || denominator <= 0) {
+    throw new Error('Fraktionella odds måste vara positiva');
+  }
+  return { numerator, denominator };
+}
+
+export function toDecimal(format: OddsFormat, value: string): number {
+  switch (format) {
+    case 'decimal':
+      return parseDecimalOdds(value);
+    case 'american':
+      return parseAmericanOdds(value);
+    case 'fraction': {
+      const { numerator, denominator } = parseFractionOdds(value);
+      return 1 + numerator / denominator;
+    }
+    default:
+      throw new Error('Okänt oddsformat');
+  }
+}
+
+export function toAmerican(decimalOdds: number): string {
+  if (decimalOdds <= 1) {
+    return '+0';
+  }
+  if (decimalOdds >= 2) {
+    const value = Math.round((decimalOdds - 1) * 100);
+    return `+${value}`;
+  }
+  const value = Math.round(100 / (decimalOdds - 1));
+  return `${value > 0 ? '-' : ''}${Math.abs(value)}`;
+}
+
+export function toFraction(decimalOdds: number): string {
+  if (decimalOdds <= 1) {
+    return '0/1';
+  }
+  const fractional = decimalOdds - 1;
+  const precision = 1000;
+  let numerator = Math.round(fractional * precision);
+  let denominator = precision;
+  const divisor = gcd(numerator, denominator);
+  numerator = numerator / divisor;
+  denominator = denominator / divisor;
+  return `${numerator}/${denominator}`;
+}
+
+export function impliedFromDecimal(decimalOdds: number): number {
+  if (decimalOdds <= 0) {
+    throw new Error('Decimalodds måste vara positiva');
+  }
+  return 1 / decimalOdds;
+}
+
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y !== 0) {
+    const temp = y;
+    y = x % y;
+    x = temp;
+  }
+  return x || 1;
+}
+
+export function formatDecimal(decimal: number, decimals = 2): string {
+  return decimal.toFixed(decimals);
+}

--- a/app/(app)/verktyg/ev/_lib/types.ts
+++ b/app/(app)/verktyg/ev/_lib/types.ts
@@ -1,0 +1,238 @@
+import { z } from 'zod';
+
+export const oddsFormatSchema = z.enum(['decimal', 'american', 'fraction']);
+export type OddsFormat = z.infer<typeof oddsFormatSchema>;
+
+export const roundingModeSchema = z.enum(['none', 'two', 'krona']);
+export type RoundingMode = z.infer<typeof roundingModeSchema>;
+
+export const edgeModeSchema = z.enum(['auto', 'manual']);
+export type EdgeMode = z.infer<typeof edgeModeSchema>;
+
+export type ProbabilitySource = 'implied' | 'manualEdge' | 'user';
+
+export const parlayLegSchema = z.object({
+  id: z.string(),
+  oddsFormat: oddsFormatSchema,
+  oddsValue: z.string({ required_error: 'Ange odds' }).min(1, 'Ange odds'),
+  ownProbability: z.string().optional(),
+});
+
+export const evFormSchema = z
+  .object({
+    oddsFormat: oddsFormatSchema,
+    oddsValue: z.string({ required_error: 'Ange odds' }).min(1, 'Ange odds'),
+    ownProbability: z.string().optional(),
+    stake: z.string({ required_error: 'Ange insats' }).min(1, 'Ange insats'),
+    bankroll: z.string().optional(),
+    edgeMode: edgeModeSchema,
+    manualEdge: z.string().optional(),
+    rounding: roundingModeSchema,
+    parlayEnabled: z.boolean().default(false),
+    parlayLegs: z.array(parlayLegSchema).default([]),
+  })
+  .superRefine((values, ctx) => {
+    const stakeNumber = parseNumber(values.stake);
+    if (stakeNumber === null || stakeNumber <= 0) {
+      ctx.addIssue({
+        path: ['stake'],
+        code: z.ZodIssueCode.custom,
+        message: 'Insatsen måste vara ett positivt tal',
+      });
+    }
+
+    const bankrollNumber = parseOptionalNumber(values.bankroll);
+    if (values.bankroll && (bankrollNumber === null || bankrollNumber <= 0)) {
+      ctx.addIssue({
+        path: ['bankroll'],
+        code: z.ZodIssueCode.custom,
+        message: 'Bankrulle måste vara ett positivt tal',
+      });
+    }
+
+    if (!validateOdds(values.oddsFormat, values.oddsValue)) {
+      ctx.addIssue({
+        path: ['oddsValue'],
+        code: z.ZodIssueCode.custom,
+        message: 'Ogiltigt oddsformat',
+      });
+    }
+
+    const probability = parseOptionalProbability(values.ownProbability);
+    if (probability === null && values.ownProbability && values.ownProbability.trim() !== '') {
+      ctx.addIssue({
+        path: ['ownProbability'],
+        code: z.ZodIssueCode.custom,
+        message: 'Sannolikhet måste vara mellan 0 och 100 %',
+      });
+    }
+
+    if (values.edgeMode === 'manual') {
+      const manualEdge = parseOptionalNumber(values.manualEdge);
+      if (manualEdge === null) {
+        ctx.addIssue({
+          path: ['manualEdge'],
+          code: z.ZodIssueCode.custom,
+          message: 'Ange din edge i procent',
+        });
+      }
+    }
+
+    if (values.parlayEnabled) {
+      if (values.parlayLegs.length === 0) {
+        ctx.addIssue({
+          path: ['parlayLegs'],
+          code: z.ZodIssueCode.custom,
+          message: 'Lägg till minst ett ben för parlay',
+        });
+      }
+
+      values.parlayLegs.forEach((leg, index) => {
+        if (!validateOdds(leg.oddsFormat, leg.oddsValue)) {
+          ctx.addIssue({
+            path: ['parlayLegs', index, 'oddsValue'],
+            code: z.ZodIssueCode.custom,
+            message: 'Ogiltiga odds för detta ben',
+          });
+        }
+        const legProbability = parseOptionalProbability(leg.ownProbability);
+        if (leg.ownProbability && legProbability === null) {
+          ctx.addIssue({
+            path: ['parlayLegs', index, 'ownProbability'],
+            code: z.ZodIssueCode.custom,
+            message: 'Sannolikhet måste vara mellan 0 och 100 %',
+          });
+        }
+      });
+    }
+  });
+
+export type EvFormValues = z.infer<typeof evFormSchema>;
+
+export interface NormalizedLeg {
+  id: string;
+  format: OddsFormat;
+  oddsInput: string;
+  decimalOdds: number;
+  impliedProbability: number;
+  ownProbability: number;
+  ownProbabilitySource: ProbabilitySource;
+  americanOdds: string;
+  fractionalOdds: string;
+}
+
+export interface NormalizedInputs {
+  stake: number;
+  bankroll?: number;
+  rounding: RoundingMode;
+  edgeMode: EdgeMode;
+  manualEdgePercent?: number;
+  baseFormat: OddsFormat;
+  decimalOdds: number;
+  impliedProbability: number;
+  ownProbability: number;
+  ownProbabilitySource: ProbabilitySource;
+  americanOdds: string;
+  fractionalOdds: string;
+  parlayLegs: NormalizedLeg[];
+  parlayEnabled: boolean;
+}
+
+export interface KellyRecommendations {
+  full: number;
+  half: number;
+  quarter: number;
+}
+
+export interface SingleResult {
+  decimalOdds: number;
+  americanOdds: string;
+  fractionalOdds: string;
+  impliedProbability: number;
+  ownProbability: number;
+  ownProbabilitySource: ProbabilitySource;
+  breakEvenProbability: number;
+  stake: number;
+  netProfit: number;
+  evValue: number;
+  roiPercent: number;
+  edgePercent: number;
+  kellyFraction: number;
+  kellyRecommendations?: KellyRecommendations;
+  bankroll?: number;
+  rounding: RoundingMode;
+  manualEdgePercent?: number;
+  warnings: string[];
+}
+
+export interface ParlayResult extends SingleResult {
+  legs: NormalizedLeg[];
+}
+
+export interface EvComputation {
+  inputs: NormalizedInputs;
+  single: SingleResult;
+  parlay?: ParlayResult;
+}
+
+function parseNumber(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const normalized = value.replace(',', '.');
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+export function parseOptionalNumber(value: string | undefined): number | null {
+  if (value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  return parseNumber(trimmed);
+}
+
+function parseOptionalProbability(value: string | undefined): number | null {
+  const parsed = parseOptionalNumber(value);
+  if (parsed === null) {
+    return null;
+  }
+  if (parsed < 0 || parsed > 100) {
+    return null;
+  }
+  return parsed / 100;
+}
+
+function validateOdds(format: OddsFormat, value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  switch (format) {
+    case 'decimal': {
+      const parsed = parseNumber(trimmed);
+      return parsed !== null && parsed > 1;
+    }
+    case 'american': {
+      const parsed = parseNumber(trimmed);
+      return parsed !== null && parsed !== 0;
+    }
+    case 'fraction': {
+      const [num, denom] = trimmed.split('/').map((part) => parseNumber(part.trim()));
+      if (num === null || denom === null) {
+        return false;
+      }
+      return num > 0 && denom > 0;
+    }
+    default:
+      return false;
+  }
+}
+
+export { parseNumber as parsePositiveNumberCandidate, parseOptionalProbability };

--- a/app/(app)/verktyg/ev/page.tsx
+++ b/app/(app)/verktyg/ev/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next';
+import * as React from 'react';
+
+import { ToastProvider } from '@/components/ui/toast';
+
+import { EvForm } from './_components/EvForm';
+import { EvResults } from './_components/EvResults';
+import { EvComputation } from './_lib/types';
+
+export const generateMetadata = (): Metadata => ({
+  title: '+EV-beräknare | Betspread',
+  description:
+    'Beräkna implied probability, förväntat värde, ROI och Kelly-fraktion för dina spel. Perfekt för att hitta +EV-spel och optimera insatser.',
+  openGraph: {
+    title: '+EV-beräknare | Betspread',
+    description:
+      'Interaktiv +EV-kalkylator med stöd för flera oddsformat, edge-hantering, Kelly och parlays.',
+    type: 'website',
+    url: 'https://www.betspread.se/verktyg/ev',
+  },
+});
+
+export default function EvPage() {
+  return (
+    <main className="bg-slate-950/80 py-12">
+      <div className="mx-auto w-full max-w-6xl px-4">
+        <EvCalculatorClient />
+      </div>
+    </main>
+  );
+}
+
+function EvCalculatorClient() {
+  'use client';
+
+  const [result, setResult] = React.useState<EvComputation | null>(null);
+
+  return (
+    <ToastProvider>
+      <section className="flex flex-col gap-8">
+        <header className="space-y-3 text-center md:text-left">
+          <p className="text-sm uppercase tracking-[0.3em] text-brand-400">Verktyg</p>
+          <h1 className="text-3xl font-bold text-slate-50 md:text-4xl">+EV-beräknare</h1>
+          <p className="text-base text-slate-300 md:max-w-2xl">
+            Ange odds, egen sannolikhet och bankrulle för att se om ditt spel har positivt förväntat värde.
+            Verktyget räknar automatiskt ut implied probability, edge, ROI och Kelly-rekommendationer.
+          </p>
+        </header>
+        <EvForm onChange={setResult} />
+        <EvResults computation={result} />
+      </section>
+    </ToastProvider>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap');
 
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   color-scheme: dark;
   --page-bg: #020617;

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: 'default' | 'destructive' | 'info';
+}
+
+const variantStyles: Record<NonNullable<AlertProps['variant']>, string> = {
+  default: 'border-brand-500/40 bg-brand-500/10 text-brand-100',
+  destructive: 'border-red-500/40 bg-red-500/10 text-red-100',
+  info: 'border-slate-500/40 bg-slate-500/10 text-slate-100',
+};
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant = 'default', ...props }, ref) => (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn(
+        'flex w-full items-start space-x-3 rounded-lg border px-4 py-3 text-sm',
+        variantStyles[variant],
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Alert.displayName = 'Alert';
+
+export { Alert };

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-slate-950',
+  {
+    variants: {
+      variant: {
+        default: 'bg-brand-500 text-white hover:bg-brand-600',
+        secondary: 'bg-slate-800 text-slate-100 hover:bg-slate-700',
+        outline:
+          'border border-slate-700 bg-transparent text-slate-100 hover:bg-slate-800/50',
+        ghost: 'bg-transparent text-slate-200 hover:bg-slate-800/70',
+        destructive: 'bg-red-600 text-white hover:bg-red-700',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8 text-base',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(buttonVariants({ variant, size }), className)}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        'rounded-xl border border-slate-800 bg-slate-900/70 p-6 shadow-card backdrop-blur-sm',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('mb-4 flex flex-col space-y-1', className)}
+    {...props}
+  />
+));
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn('text-lg font-semibold tracking-tight text-slate-50', className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('space-y-4', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
+
+export { Card, CardContent, CardHeader, CardTitle };

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-sm transition-colors placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        'text-sm font-medium text-slate-200 leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Label.displayName = 'Label';
+
+export { Label };

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => (
+    <select
+      ref={ref}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </select>
+  )
+);
+Select.displayName = 'Select';
+
+export { Select };

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+type ToastVariant = 'default' | 'success' | 'destructive';
+
+export interface ToastOptions {
+  title?: string;
+  description?: string;
+  variant?: ToastVariant;
+  duration?: number;
+}
+
+interface ToastInstance extends ToastOptions {
+  id: number;
+}
+
+interface ToastContextValue {
+  toast: (options: ToastOptions) => void;
+  dismiss: (id: number) => void;
+}
+
+const ToastContext = React.createContext<ToastContextValue | undefined>(undefined);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = React.useState<ToastInstance[]>([]);
+
+  const dismiss = React.useCallback((id: number) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const toast = React.useCallback(
+    ({ duration = 3500, ...options }: ToastOptions) => {
+      setToasts((prev) => {
+        const id = Date.now() + Math.random();
+        const next: ToastInstance = { id, ...options };
+        window.setTimeout(() => dismiss(id), duration);
+        return [...prev, next];
+      });
+    },
+    [dismiss]
+  );
+
+  return (
+    <ToastContext.Provider value={{ toast, dismiss }}>
+      {children}
+      <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col space-y-2">
+        {toasts.map(({ id, title, description, variant = 'default' }) => (
+          <div
+            key={id}
+            className={cn(
+              'pointer-events-auto overflow-hidden rounded-lg border px-4 py-3 text-sm shadow-lg backdrop-blur',
+              variant === 'destructive'
+                ? 'border-red-600 bg-red-600/10 text-red-100'
+                : variant === 'success'
+                ? 'border-emerald-500/70 bg-emerald-500/10 text-emerald-100'
+                : 'border-slate-700 bg-slate-900/90 text-slate-100'
+            )}
+          >
+            {title ? <p className="font-semibold">{title}</p> : null}
+            {description ? <p className="mt-1 text-sm opacity-90">{description}</p> : null}
+            <button
+              type="button"
+              aria-label="Stäng"
+              onClick={() => dismiss(id)}
+              className="mt-2 inline-flex text-xs font-medium text-slate-300 underline-offset-2 hover:underline"
+            >
+              Stäng
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const context = React.useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast måste användas inom en ToastProvider');
+  }
+  return context;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,5 @@
+import { type ClassValue, clsx } from 'clsx';
+
+export function cn(...inputs: ClassValue[]): string {
+  return clsx(inputs);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -10,14 +10,32 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node --test"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
     "@supabase/supabase-js": "^2.45.4",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
     "next": "^14.2.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.51.5",
     "raw-body": "^2.5.2",
-    "stripe": "^14.25.0"
+    "stripe": "^14.25.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitest/coverage-v8": "^1.6.0",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.6",
+    "typescript": "^5.5.3",
+    "vitest": "^1.6.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,32 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ['class'],
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './lib/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          50: '#eef2ff',
+          100: '#e0e7ff',
+          200: '#c7d2fe',
+          300: '#a5b4fc',
+          400: '#818cf8',
+          500: '#6366f1',
+          600: '#4f46e5',
+          700: '#4338ca',
+          800: '#3730a3',
+          900: '#312e81',
+        },
+      },
+      boxShadow: {
+        card: '0 20px 25px -15px rgba(15, 23, 42, 0.4)',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tests/ev/ev.spec.ts
+++ b/tests/ev/ev.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { calculateEv, evCurrency, kellyFraction, roiPercent } from '../../app/(app)/verktyg/ev/_lib/ev';
+import { toAmerican, toDecimal, toFraction, impliedFromDecimal } from '../../app/(app)/verktyg/ev/_lib/odds';
+import { EvFormValues } from '../../app/(app)/verktyg/ev/_lib/types';
+
+function formValues(overrides: Partial<EvFormValues> = {}): EvFormValues {
+  return {
+    oddsFormat: 'decimal',
+    oddsValue: '2.00',
+    ownProbability: '55',
+    stake: '100',
+    bankroll: '',
+    edgeMode: 'auto',
+    manualEdge: '',
+    rounding: 'none',
+    parlayEnabled: false,
+    parlayLegs: [],
+    ...overrides,
+  };
+}
+
+describe('odds-konvertering', () => {
+  it('konverterar amerikanska odds till decimal', () => {
+    expect(toDecimal('american', '+150')).toBeCloseTo(2.5, 3);
+    expect(toDecimal('american', '-200')).toBeCloseTo(1.5, 3);
+  });
+
+  it('konverterar fraktionella odds till decimal', () => {
+    expect(toDecimal('fraction', '5/2')).toBeCloseTo(3.5, 3);
+  });
+
+  it('ger implied probability från decimalodds', () => {
+    expect(impliedFromDecimal(2)).toBeCloseTo(0.5, 4);
+  });
+
+  it('konverterar decimal till amerikanska och fraktion', () => {
+    const decimal = 1.91;
+    const american = toAmerican(decimal);
+    const fraction = toFraction(decimal);
+    expect(american.startsWith('-')).toBe(true);
+    expect(fraction).toContain('/');
+  });
+});
+
+describe('EV-beräkningar', () => {
+  it('uppfyller acceptanskriterium 1 (decimal)', () => {
+    const result = calculateEv(formValues());
+    const single = result.single;
+    expect(single.impliedProbability).toBeCloseTo(0.5, 4);
+    expect(single.breakEvenProbability).toBeCloseTo(0.5, 4);
+    expect(single.evValue).toBeCloseTo(10, 4);
+    expect(single.roiPercent).toBeCloseTo(10, 4);
+    expect(single.kellyFraction).toBeCloseTo(0.1, 3);
+  });
+
+  it('uppfyller acceptanskriterium 2 (amerikanska odds)', () => {
+    const result = calculateEv(
+      formValues({ oddsFormat: 'american', oddsValue: '+150', ownProbability: '45' })
+    );
+    const single = result.single;
+    expect(single.decimalOdds).toBeCloseTo(2.5, 3);
+    expect(single.impliedProbability).toBeCloseTo(0.4, 4);
+    expect(single.evValue).toBeCloseTo(12.5, 2);
+    expect(single.roiPercent).toBeCloseTo(12.5, 2);
+    expect(single.kellyFraction).toBeCloseTo(0.0667, 3);
+  });
+
+  it('uppfyller acceptanskriterium 3 (fraktion)', () => {
+    const result = calculateEv(
+      formValues({ oddsFormat: 'fraction', oddsValue: '5/2', ownProbability: '33', stake: '200' })
+    );
+    const single = result.single;
+    expect(single.decimalOdds).toBeCloseTo(3.5, 3);
+    expect(single.impliedProbability).toBeCloseTo(2 / 7, 3);
+    expect(single.evValue).toBeCloseTo(-5, 1);
+    expect(single.kellyFraction).toBeCloseTo(0.032, 3);
+  });
+
+  it('visar negativ Kelly', () => {
+    const result = calculateEv(
+      formValues({ oddsFormat: 'decimal', oddsValue: '2.20', ownProbability: '40', stake: '100', bankroll: '1000' })
+    );
+    const single = result.single;
+    expect(single.kellyFraction).toBe(0);
+    expect(single.warnings.some((msg) => msg.includes('negativ'))).toBe(true);
+  });
+
+  it('uppfyller acceptanskriterium 5 (parlay)', () => {
+    const result = calculateEv(
+      formValues({
+        parlayEnabled: true,
+        parlayLegs: [
+          { id: 'leg-1', oddsFormat: 'decimal', oddsValue: '2.00', ownProbability: '55' },
+          { id: 'leg-2', oddsFormat: 'decimal', oddsValue: '1.80', ownProbability: '60' },
+        ],
+      })
+    );
+    const parlay = result.parlay!;
+    expect(parlay.decimalOdds).toBeCloseTo(3.6, 2);
+    expect(parlay.ownProbability).toBeCloseTo(0.33, 2);
+    expect(parlay.breakEvenProbability).toBeCloseTo(1 / 3.6, 3);
+    expect(parlay.roiPercent).toBeCloseTo(18.8, 1);
+  });
+
+  it('hanterar manuell edge', () => {
+    const result = calculateEv(
+      formValues({
+        edgeMode: 'manual',
+        manualEdge: '5',
+        ownProbability: '',
+        oddsValue: '2.00',
+      })
+    );
+    const single = result.single;
+    expect(single.edgePercent).toBeCloseTo(5, 4);
+    expect(single.ownProbability).toBeCloseTo(0.55, 4);
+  });
+
+  it('räknar fram EV/ROI/Kelly direkt', () => {
+    const odds = 2.5;
+    const probability = 0.45;
+    const stake = 100;
+    expect(roiPercent(odds, probability)).toBeCloseTo(12.5, 3);
+    expect(evCurrency(odds, probability, stake)).toBeCloseTo(12.5, 3);
+    expect(kellyFraction(odds, probability)).toBeCloseTo(0.0667, 3);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.spec.ts'],
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- build a +EV-kalkylator på /verktyg/ev med React Hook Form, Zod-validering, edge-lägen och parlay-stöd
- lägga till odds- och EV-utilityfunktioner samt dokumentation och Vitest-svit med acceptanstester
- konfigurera Tailwind/PostCSS och skapa återanvändbara shadcn-inspirerade UI-komponenter för formulär och resultat

## Testing
- `pnpm lint` *(misslyckas: `next` saknas eftersom npm-registret blockerar installationer i miljön)*
- `pnpm typecheck` *(misslyckas: `@types/react` och relaterade paket kunde inte installeras på grund av 403 från registret)*
- `pnpm test` *(misslyckas: `vitest` kunde inte installeras i miljön)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9bd8e668832b8d538bb2c0aa22c7